### PR TITLE
Enhance document translation with parallel processing and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,71 @@
-# Service
+# KO-JP Patent Translator
 
 [<img width="2880" height="1704" alt="한일 특허 번역기" src="https://github.com/user-attachments/assets/ff3fcead-1e9d-4c9f-81fe-ec44f6040655" />](https://ko-jp-patent-translator.streamlit.app/)
 
-# Pipeline
+한국어 특허 `.docx` 문서를 업로드하면,  
+**일본어 특허 문체에 맞춰 번역된 `.docx` 파일**을 다운로드할 수 있는 번역 서비스입니다.
+
+-   입력: `.docx` 특허 문서
+-   출력: 일본어 특허 문체의 `.docx`
+-   텍스트와 도면(이미지 내 텍스트)을 모두 처리
+
+---
+
+## ✨ Highlights
+
+-   `.docx` 문서를 요소 단위(텍스트 / 도면)로 파싱
+-   텍스트는 문장 구조를 최대한 유지하며 chunk 단위로 번역
+-   도면 이미지는 OCR성 텍스트 추출 + `[원문 - 번역]` 형식 생성
+-   출력 문서는 **MS Mincho 10.5pt** 기준으로 생성
+-   **병렬 처리 기반 pipeline**으로 전체 번역 시간 단축
+
+---
+
+## 🚀 Run Locally
+
+1. `.streamlit/secrets.toml` 파일 생성
+    ```
+    GEMINI_API_KEY = "your_gemini_api_key"
+    ```
+2. 앱 실행
+    ```
+    python -m streamlit run app.py
+    ```
+
+---
+
+## 🔄 Pipeline Overview
+
+### Parallel (개선)
+
+```mermaid
+flowchart TD
+  A["[Streamlit]<br/>번역할 .docx 파일 업로드"]
+  B["문서 파싱<br/>(텍스트 / 도면 요소 추출)"]
+  C["텍스트 chunk 분할<br/>(문장 단위 최대한 유지)"]
+  D["출력용 .docx 초기화<br/>(MS Mincho 10.5pt)"]
+
+  E{"요소 타입 분기"}
+  T["텍스트 번역 작업 생성"]
+  I["도면 텍스트 번역 작업 생성"]
+
+  subgraph P["Parallel Processing"]
+    direction TB
+    PT["텍스트 chunk 병렬 번역"]
+    PI["도면 OCR/텍스트 병렬 처리"]
+  end
+
+  M["원래 순서 기준 결과 병합"]
+  W["출력용 .docx에 결과 반영"]
+  Z["[Streamlit]]<br/>번역된 .docx 다운로드"]
+
+  A --> B --> C --> D --> E
+  E -->|텍스트| T --> PT --> M
+  E -->|도면| I --> PI --> M
+  M --> W --> Z
+```
+
+### Sequential (기존)
 
 ```mermaid
 flowchart TD
@@ -29,20 +92,14 @@ flowchart TD
   D -->|모두 처리됨| A7
 ```
 
-※ Gemini API 유료 Tier 1 사용 중
+> [!NOTE]
+>
+> -   Gemini API 유료 Tier 1 사용 중
+> -   AI 번역의 품질 한계로 인해 검수를 통한 후편집 필요
 
-## 실행
+---
 
--   `.streamlit/secrets.toml` 파일 생성
-    ```
-    GEMINI_API_KEY = "your_gemini_api_key"
-    ```
--   앱 실행
-    ```
-    python -m streamlit run app.py
-    ```
-
-## 벤치마크 (순차 vs 병렬)
+## ⏱️ Benchmark Script (순차 vs 병렬)
 
 동일 문서로 순차/병렬 번역 소요 시간을 비교하려면:
 
@@ -51,8 +108,22 @@ export GEMINI_API_KEY="your_key"
 python scripts/benchmark_translation.py path/to/patent.docx
 ```
 
-`--sequential-only` 또는 `--parallel-only` 로 한쪽만 실행할 수 있다. 결과에 순차 시간, 병렬 시간, speedup 배수가 출력된다.
+옵션:
 
-## 참고자료
+-   `--sequential-only`
+-   `--parallel-only`
+    실행 결과에는 순차 시간, 병렬 시간, speedup 배수가 출력됩니다.
+
+### Result (25 청크 특허 문서)
+
+| 구분                 | 소요 시간    |
+| -------------------- | ------------ |
+| 순차                 | 269.8s       |
+| 병렬 (max_workers=8) | 45.6s        |
+| **Speedup**          | **약 5.92x** |
+
+---
+
+## 🔗 Reference
 
 https://ai.google.dev/gemini-api/docs/structured-output?hl=ko&lang=python

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ flowchart TD
   D -->|모두 처리됨| A7
 ```
 
-※ 현재는 사전 사용 안하는 버전 & 비용 이슈로 무료인 Gemini api 사용
+※ Gemini API 유료 Tier 1 사용 중
 
 ## 실행
 
@@ -41,6 +41,17 @@ flowchart TD
     ```
     python -m streamlit run app.py
     ```
+
+## 벤치마크 (순차 vs 병렬)
+
+동일 문서로 순차/병렬 번역 소요 시간을 비교하려면:
+
+```bash
+export GEMINI_API_KEY="your_key"
+python scripts/benchmark_translation.py path/to/patent.docx
+```
+
+`--sequential-only` 또는 `--parallel-only` 로 한쪽만 실행할 수 있다. 결과에 순차 시간, 병렬 시간, speedup 배수가 출력된다.
 
 ## 참고자료
 

--- a/app.py
+++ b/app.py
@@ -60,8 +60,11 @@ else:
 
 # 파일 업로드 시 문서 파싱
 if uploaded_file and not st.session_state.translated:
+    progress_placeholder.progress(0, text="📄 문서 파싱 중...")
     elements = parse_docx_with_images(uploaded_file)
+    progress_placeholder.progress(0.5, text="📄 청크 구성 중...")
     chunks = group_paragraphs_to_chunks(elements)
+    progress_placeholder.progress(1.0, text="✅ 문서 분석 완료")
     st.session_state.parsed_elements = elements
     st.session_state.chunked_elements = chunks
 
@@ -71,6 +74,8 @@ def run_translation():
     doc = create_japanese_patent_docx()
     total = len(st.session_state.chunked_elements)
     paragraph_counter = 0
+
+    progress_placeholder.progress(0, text=f"🔄 번역 중... 0 / {total} 청크 완료")
 
     for i, chunk in enumerate(st.session_state.chunked_elements):
         if chunk["type"] == "TEXT":

--- a/app.py
+++ b/app.py
@@ -11,9 +11,9 @@ from utils import (
     create_japanese_patent_docx,
     group_paragraphs_to_chunks,
     parse_docx_with_images,
-    translate_image_with_gemini,
-    translate_text_with_gemini,
+    translate_chunks_parallel,
 )
+from utils.config import TRANSLATION_MAX_WORKERS
 
 # 초기 상태
 if "translated" not in st.session_state:
@@ -69,24 +69,15 @@ if uploaded_file and not st.session_state.translated:
     st.session_state.chunked_elements = chunks
 
 
-# 번역 실행
-def run_translation():
-    doc = create_japanese_patent_docx()
-    total = len(st.session_state.chunked_elements)
+def build_doc_from_translated_chunks(doc, chunks):
+    """Write translated chunks (with chunk['translated'] set) into doc in order."""
     paragraph_counter = 0
-
-    progress_placeholder.progress(0, text=f"🔄 번역 중... 0 / {total} 청크 완료")
-
-    for i, chunk in enumerate(st.session_state.chunked_elements):
+    for chunk in chunks:
         if chunk["type"] == "TEXT":
-            translated = translate_text_with_gemini(
-                chunk["content"], DEFAULT_GEMINI_MODEL_NAME
-            )
+            translated = chunk["translated"]
             for line in translated.split("\n"):
                 if line.strip():
-                    # 제목은 단락 번호를 붙이지 않음 -> 제목이 아닌 line에 대해 단락 번호 추가
                     if not (line.startswith("【") and line.endswith("】")):
-                        # 첫 번째 단락은 특허 명칭에 대한 단락이므로 번호를 붙이지 않음
                         if paragraph_counter == 0:
                             paragraph_counter += 1
                         else:
@@ -96,19 +87,35 @@ def run_translation():
                     doc.add_paragraph_with_justify(" " + line)
                 else:
                     doc.add_paragraph_with_justify("")
-            chunk["translated"] = translated
         elif chunk["type"] == "FIGURE":
-            translated_pairs = translate_image_with_gemini(
-                chunk["content"], DEFAULT_GEMINI_MODEL_NAME
-            )
-            formatted = [f"{p.original}: {p.translated}" for p in translated_pairs]
+            formatted = [
+                f"{p.original}: {p.translated}" for p in chunk["translated"]
+            ]
             for line in formatted:
                 doc.add_paragraph_with_justify(line)
-            chunk["translated"] = formatted
 
+
+# 번역 실행
+def run_translation():
+    chunks = st.session_state.chunked_elements
+    total = len(chunks)
+    doc = create_japanese_patent_docx()
+
+    def progress_cb(completed, total_n):
         progress_placeholder.progress(
-            (i + 1) / total, text=f"🔄 번역 중... {i + 1} / {total} 청크 완료"
+            completed / total_n,
+            text=f"🔄 번역 중... {completed} / {total_n} 청크 완료",
         )
+
+    progress_placeholder.progress(0, text=f"🔄 번역 중... 0 / {total} 청크 완료")
+    translated_chunks = translate_chunks_parallel(
+        chunks,
+        model_name=DEFAULT_GEMINI_MODEL_NAME,
+        max_workers=TRANSLATION_MAX_WORKERS,
+        progress_callback=progress_cb,
+    )
+    st.session_state.chunked_elements = translated_chunks
+    build_doc_from_translated_chunks(doc, translated_chunks)
 
     with tempfile.NamedTemporaryFile(delete=False, suffix=".docx") as tmp_file:
         doc.save(tmp_file.name)

--- a/scripts/benchmark_translation.py
+++ b/scripts/benchmark_translation.py
@@ -1,0 +1,89 @@
+"""
+Benchmark: sequential vs parallel translation on the same .docx.
+Requires GEMINI_API_KEY in environment (e.g. export GEMINI_API_KEY=... or set in shell).
+
+Usage:
+  python scripts/benchmark_translation.py path/to/patent.docx
+  python scripts/benchmark_translation.py path/to/patent.docx --sequential-only
+  python scripts/benchmark_translation.py path/to/patent.docx --parallel-only
+"""
+
+import argparse
+import os
+import sys
+import time
+
+# Project root on path for utils
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.chunker import group_paragraphs_to_chunks
+from utils.docx_parser import parse_docx_with_images
+from utils.config import TRANSLATION_MAX_WORKERS
+from utils.translation_runner import (
+    translate_chunks_parallel,
+    translate_chunks_sequential,
+)
+
+
+def _parse_and_chunk(docx_path: str):
+    with open(docx_path, "rb") as f:
+        elements = parse_docx_with_images(f)
+    return group_paragraphs_to_chunks(elements)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark sequential vs parallel translation")
+    parser.add_argument("docx", help="Path to .docx file")
+    parser.add_argument("--sequential-only", action="store_true", help="Run only sequential")
+    parser.add_argument("--parallel-only", action="store_true", help="Run only parallel")
+    args = parser.parse_args()
+
+    if not os.environ.get("GEMINI_API_KEY"):
+        print("Error: Set GEMINI_API_KEY in the environment.", file=sys.stderr)
+        sys.exit(1)
+
+    docx_path = args.docx
+    if not os.path.isfile(docx_path):
+        print(f"Error: File not found: {docx_path}", file=sys.stderr)
+        sys.exit(1)
+
+    run_seq = not args.parallel_only
+    run_par = not args.sequential_only
+    chunk_count = len(_parse_and_chunk(docx_path))
+    print(f"Chunks: {chunk_count}")
+    print()
+
+    t_seq = None
+    t_par = None
+
+    if run_seq:
+        chunks_seq = _parse_and_chunk(docx_path)
+        print("Running sequential translation...")
+        t0 = time.perf_counter()
+        translate_chunks_sequential(chunks_seq)
+        t_seq = time.perf_counter() - t0
+        print(f"  Sequential: {t_seq:.1f}s")
+
+    if run_par:
+        chunks_par = _parse_and_chunk(docx_path)
+        print("Running parallel translation...")
+        t0 = time.perf_counter()
+        translate_chunks_parallel(
+            chunks_par,
+            max_workers=TRANSLATION_MAX_WORKERS,
+        )
+        t_par = time.perf_counter() - t0
+        print(f"  Parallel:   {t_par:.1f}s")
+
+    print()
+    if t_seq is not None and t_par is not None:
+        speedup = t_seq / t_par
+        print(f"Summary: sequential {t_seq:.1f}s, parallel {t_par:.1f}s, speedup {speedup:.2f}x")
+    elif t_seq is not None:
+        print(f"Summary: sequential {t_seq:.1f}s")
+    elif t_par is not None:
+        print(f"Summary: parallel {t_par:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,7 +1,7 @@
 from .chunker import group_paragraphs_to_chunks
 from .config import DEFAULT_GEMINI_MODEL_DISPLAY_NAME, DEFAULT_GEMINI_MODEL_NAME
 from .docx_parser import create_japanese_patent_docx, parse_docx_with_images
-from .translation import translate_image_with_gemini, translate_text_with_gemini
+from .translation_runner import translate_chunks_parallel
 
 __all__ = [
     "create_japanese_patent_docx",
@@ -9,6 +9,5 @@ __all__ = [
     "DEFAULT_GEMINI_MODEL_NAME",
     "group_paragraphs_to_chunks",
     "parse_docx_with_images",
-    "translate_image_with_gemini",
-    "translate_text_with_gemini",
+    "translate_chunks_parallel",
 ]

--- a/utils/config.py
+++ b/utils/config.py
@@ -2,6 +2,9 @@
 DEFAULT_GEMINI_MODEL_NAME = "gemini-2.5-flash"
 DEFAULT_GEMINI_MODEL_DISPLAY_NAME = "Gemini 2.5 Flash"
 
+# Parallel translation: max concurrent API requests (Tier 1 friendly)
+TRANSLATION_MAX_WORKERS = 8
+
 # Prompts for translation
 TEXT_TRANSLATION_PROMPT = (
     "You are a professional patent translator specializing in Korean-to-Japanese patents. "

--- a/utils/config.py
+++ b/utils/config.py
@@ -20,6 +20,7 @@ TEXT_TRANSLATION_PROMPT = (
     "6. Prefer standard Japanese patent terminology.\n"
     "7. Keep technical terms consistent throughout the document.\n"
     "8. Do NOT omit any content, even if repetitive.\n"
+    "9. Preserve all line breaks from the source text."
     "The goal is a structurally equivalent Japanese version suitable for human post-editing."
 )
 

--- a/utils/translation.py
+++ b/utils/translation.py
@@ -1,7 +1,7 @@
 import logging
+import os
 import time
 
-import streamlit as st
 from google import genai
 from google.genai.errors import ClientError
 from pydantic import BaseModel
@@ -12,8 +12,23 @@ from utils.config import (
     TEXT_TRANSLATION_PROMPT,
 )
 
-# Gemini API 설정
-client = genai.Client(api_key=st.secrets["GEMINI_API_KEY"])
+# Gemini API client (lazy: supports Streamlit secrets or GEMINI_API_KEY env for benchmark)
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is not None:
+        return _client
+    try:
+        import streamlit as st
+        api_key = st.secrets["GEMINI_API_KEY"]
+    except Exception:
+        api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise RuntimeError("GEMINI_API_KEY not found in st.secrets or GEMINI_API_KEY env")
+    _client = genai.Client(api_key=api_key)
+    return _client
 
 
 # 구조화 모델
@@ -71,7 +86,7 @@ def translate_text_with_gemini(
     model_name: str = DEFAULT_GEMINI_MODEL_NAME,
 ) -> str:
     def call_gemini_api():
-        response = client.models.generate_content(
+        response = _get_client().models.generate_content(
             model=model_name,
             contents=[TEXT_TRANSLATION_PROMPT, text],
             config={
@@ -89,7 +104,7 @@ def translate_image_with_gemini(
     model_name: str = DEFAULT_GEMINI_MODEL_NAME,
 ) -> list[ImageTranslation]:
     def call_gemini_api():
-        response = client.models.generate_content(
+        response = _get_client().models.generate_content(
             model=model_name,
             contents=[IMAGE_TRANSLATION_PROMPT, pil_image],
             config={

--- a/utils/translation.py
+++ b/utils/translation.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import threading
 import time
 
 from google import genai
@@ -12,23 +13,30 @@ from utils.config import (
     TEXT_TRANSLATION_PROMPT,
 )
 
-# Gemini API client (lazy: supports Streamlit secrets or GEMINI_API_KEY env for benchmark)
-_client = None
+# API key resolved once (main thread or first thread that needs it)
+_api_key = None
+_api_key_lock = threading.Lock()
+
+# One client per thread so worker threads don't share httpx client (avoids "client has been closed")
+_tls = threading.local()
 
 
 def _get_client():
-    global _client
-    if _client is not None:
-        return _client
-    try:
-        import streamlit as st
-        api_key = st.secrets["GEMINI_API_KEY"]
-    except Exception:
-        api_key = os.environ.get("GEMINI_API_KEY")
-    if not api_key:
-        raise RuntimeError("GEMINI_API_KEY not found in st.secrets or GEMINI_API_KEY env")
-    _client = genai.Client(api_key=api_key)
-    return _client
+    global _api_key
+    with _api_key_lock:
+        if _api_key is None:
+            try:
+                import streamlit as st
+                _api_key = st.secrets["GEMINI_API_KEY"]
+            except Exception:
+                _api_key = os.environ.get("GEMINI_API_KEY")
+            if not _api_key:
+                raise RuntimeError(
+                    "GEMINI_API_KEY not found in st.secrets or GEMINI_API_KEY env"
+                )
+    if not getattr(_tls, "client", None):
+        _tls.client = genai.Client(api_key=_api_key)
+    return _tls.client
 
 
 # 구조화 모델

--- a/utils/translation_runner.py
+++ b/utils/translation_runner.py
@@ -1,0 +1,60 @@
+"""Run translation over chunks: sequential (benchmark only) and parallel (app)."""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from utils.config import DEFAULT_GEMINI_MODEL_NAME
+from utils.translation import translate_image_with_gemini, translate_text_with_gemini
+
+
+def _translate_single_chunk(chunk: dict, model_name: str) -> dict:
+    """Translate one chunk in-place (sets chunk['translated']) and return the same chunk."""
+    if chunk["type"] == "TEXT":
+        chunk["translated"] = translate_text_with_gemini(
+            chunk["content"], model_name
+        )
+    elif chunk["type"] == "FIGURE":
+        translated_pairs = translate_image_with_gemini(
+            chunk["content"], model_name
+        )
+        chunk["translated"] = translated_pairs
+    return chunk
+
+
+def translate_chunks_sequential(
+    chunks: list[dict],
+    model_name: str = DEFAULT_GEMINI_MODEL_NAME,
+    progress_callback=None,
+) -> list[dict]:
+    """Translate chunks one by one. Used by benchmark only."""
+    for i, chunk in enumerate(chunks):
+        _translate_single_chunk(chunk, model_name)
+        if progress_callback is not None:
+            progress_callback(i + 1, len(chunks))
+    return chunks
+
+
+def translate_chunks_parallel(
+    chunks: list[dict],
+    model_name: str = DEFAULT_GEMINI_MODEL_NAME,
+    max_workers: int = 8,
+    progress_callback=None,
+) -> list[dict]:
+    """Translate chunks in parallel; return chunks in original order with 'translated' set."""
+    total = len(chunks)
+    results: list[dict | None] = [None] * total
+
+    def task(index: int):
+        chunk = chunks[index]
+        return index, _translate_single_chunk(dict(chunk), model_name)
+
+    completed = 0
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(task, i): i for i in range(total)}
+        for future in as_completed(futures):
+            index, translated_chunk = future.result()
+            results[index] = translated_chunk
+            completed += 1
+            if progress_callback is not None:
+                progress_callback(completed, total)
+
+    return [c for c in results if c is not None]


### PR DESCRIPTION

## Summary

번역 파이프라인을 **순차 처리에서 병렬 처리로 전환**했습니다. 동일 문서 기준 처리 시간이 크게 단축되며, 출력 순서는 기존과 동일하게 유지됩니다.

<img width="2917" height="1370" alt="image" src="https://github.com/user-attachments/assets/f2f73a70-5b41-4d3f-b472-16ff7bf725eb" />

---

## What Changed

### Before

* 요소를 하나씩 순차 처리
* chunk 수가 많아질수록 전체 대기 시간이 길어짐
* 이미지/텍스트 작업이 모두 직렬로 이어짐

### After

* 번역 가능한 작업을 병렬로 실행
* 전체 처리 시간 단축
* 문서의 **최종 출력 순서는 유지**하면서 처리만 병렬화

---

## Benchmark

25 청크의 동일 특허 문서 기준, 순차 처리와 병렬 처리의 시간을 비교했습니다.

| 구분                 | 소요 시간    |
| -------------------- | ------------ |
| 순차                 | 269.8s       |
| 병렬 (max_workers=8) | 45.6s        |
| **Speedup**          | **약 5.92x** |

---

## Sequential vs Parallel

### Sequential Pipeline

기존 방식은 각 요소를 하나씩 처리했습니다.

```mermaid
flowchart LR
  A["요소 1 처리"] --> B["요소 2 처리"] --> C["요소 3 처리"] --> D["..."]
```

단점:

* 긴 문서에서 전체 대기 시간 증가
* 텍스트 / 도면 작업이 모두 직렬 처리됨

### Parallel Pipeline

현재 방식은 독립적으로 처리 가능한 작업을 병렬 실행합니다.

```mermaid
flowchart TD
  A["작업 목록 생성"]
  B1["텍스트 작업 1"]
  B2["텍스트 작업 2"]
  B3["도면 작업 1"]
  B4["텍스트 작업 3"]
  C["결과 병합 및 순서 복원"]

  A --> B1 --> C
  A --> B2 --> C
  A --> B3 --> C
  A --> B4 --> C
```

핵심 포인트:

* 처리 자체는 병렬
* 결과 반영은 원래 문서 순서 유지

---

## Key changes

* `utils/config.py`: `TRANSLATION_MAX_WORKERS = 8` 추가 (Tier 1 대비)
* `utils/translation.py`: lazy client, `GEMINI_API_KEY` env 지원, **thread-local client** (병렬 호출 시 closed client 오류 방지)
* `utils/translation_runner.py`: `translate_chunks_sequential`(벤치마크용), `translate_chunks_parallel`(앱용) 추가
* `app.py`: `build_doc_from_translated_chunks` 분리, `run_translation`에서 병렬 번역 사용
* `scripts/benchmark_translation.py`: 순차 vs 병렬 소요 시간·speedup 측정 스크립트 추가
* README: 파이프라인 개요, 벤치마크 요약 등으로 정리

