### PR TITLE
Enhance paragraph-preserving translation with structured text output

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,11 +60,8 @@ else:
 
 # 파일 업로드 시 문서 파싱
 if uploaded_file and not st.session_state.translated:
-    progress_placeholder.progress(0, text="📄 문서 파싱 중...")
     elements = parse_docx_with_images(uploaded_file)
-    progress_placeholder.progress(0.5, text="📄 청크 구성 중...")
     chunks = group_paragraphs_to_chunks(elements)
-    progress_placeholder.progress(1.0, text="✅ 문서 분석 완료")
     st.session_state.parsed_elements = elements
     st.session_state.chunked_elements = chunks
 
@@ -74,25 +71,21 @@ def build_doc_from_translated_chunks(doc, chunks):
     paragraph_counter = 0
     for chunk in chunks:
         if chunk["type"] == "TEXT":
-            translated = chunk["translated"]
-            for line in translated.split("\n"):
-                if line.strip():
-                    if not (line.startswith("【") and line.endswith("】")):
+            for para in chunk["translated"]:
+                if para.strip():
+                    if not (para.startswith("【") and para.endswith("】")):
                         if paragraph_counter == 0:
                             paragraph_counter += 1
                         else:
                             paragraph_number = f" 【{paragraph_counter:04d}】"
                             paragraph_counter += 1
                             doc.add_paragraph_with_justify(" " + paragraph_number)
-                    doc.add_paragraph_with_justify(" " + line)
+                    doc.add_paragraph_with_justify(" " + para)
                 else:
                     doc.add_paragraph_with_justify("")
         elif chunk["type"] == "FIGURE":
-            formatted = [
-                f"{p.original}: {p.translated}" for p in chunk["translated"]
-            ]
-            for line in formatted:
-                doc.add_paragraph_with_justify(line)
+            for p in chunk["translated"]:
+                doc.add_paragraph_with_justify(f"{p.original}: {p.translated}")
 
 
 # 번역 실행
@@ -144,5 +137,14 @@ if st.session_state.translated:
 
     # 번역 결과 표시
     with st.expander("📘 최종 번역 결과 (청크 단위)", expanded=False):
-        df = pd.DataFrame(st.session_state.chunked_elements)
-        st.dataframe(df, width="stretch")
+        display_rows = []
+        for c in st.session_state.chunked_elements:
+            row = {"type": c["type"]}
+            if c["type"] == "TEXT":
+                row["content"] = "\n".join(c["content"])
+                row["translated"] = "\n".join(c.get("translated", []))
+            elif c["type"] == "FIGURE":
+                row["content"] = "(image)"
+                row["translated"] = str(c.get("translated", ""))
+            display_rows.append(row)
+        st.dataframe(pd.DataFrame(display_rows), use_container_width=True)

--- a/utils/chunker.py
+++ b/utils/chunker.py
@@ -4,15 +4,15 @@ def group_paragraphs_to_chunks(elements, max_words=2000):
         if elem["type"] == "TEXT":
             words = len(elem["content"].split())
             if word_count + words > max_words and buffer:
-                chunks.append({"type": "TEXT", "content": "\n".join(buffer)})
+                chunks.append({"type": "TEXT", "content": list(buffer)})
                 buffer, word_count = [], 0
             buffer.append(elem["content"])
             word_count += words
         elif elem["type"] == "FIGURE":
             if buffer:
-                chunks.append({"type": "TEXT", "content": "\n".join(buffer)})
+                chunks.append({"type": "TEXT", "content": list(buffer)})
                 buffer, word_count = [], 0
             chunks.append(elem)
     if buffer:
-        chunks.append({"type": "TEXT", "content": "\n".join(buffer)})
+        chunks.append({"type": "TEXT", "content": list(buffer)})
     return chunks

--- a/utils/config.py
+++ b/utils/config.py
@@ -8,20 +8,19 @@ TRANSLATION_MAX_WORKERS = 8
 # Prompts for translation
 TEXT_TRANSLATION_PROMPT = (
     "You are a professional patent translator specializing in Korean-to-Japanese patents. "
-    "Translate the following Korean patent text into Japanese in a strict, literal manner. "
-    "Perform direct sentence-by-sentence translation without summarizing, paraphrasing, "
-    "reorganizing, or improving the structure. "
+    "You will receive a JSON array of Korean patent paragraphs. "
+    "Translate each paragraph into Japanese and return a JSON array of the same length. "
+    "Each element in the output array must be the translated version of the corresponding input element. "
     "Follow these rules strictly:\n"
-    "1. Preserve the original document structure exactly (headings, numbering, paragraph breaks, symbols).\n"
-    "2. Do NOT merge, split, reorder, or restructure sentences.\n"
-    "3. Translate each sentence in the same order as the source text.\n"
+    "1. The output array MUST have exactly the same number of elements as the input array.\n"
+    "2. Translate each paragraph independently in order; do NOT merge, split, or reorder.\n"
+    "3. Preserve headings, numbering, and symbols within each paragraph.\n"
     "4. Do NOT add explanations, clarifications, or additional wording.\n"
     "5. Use formal Japanese patent specification style appropriate for JPO filings.\n"
     "6. Prefer standard Japanese patent terminology.\n"
-    "7. Keep technical terms consistent throughout the document.\n"
+    "7. Keep technical terms consistent throughout.\n"
     "8. Do NOT omit any content, even if repetitive.\n"
-    "9. Preserve all line breaks from the source text."
-    "The goal is a structurally equivalent Japanese version suitable for human post-editing."
+    "9. Empty strings in the input must remain empty strings in the output.\n"
 )
 
 

--- a/utils/translation.py
+++ b/utils/translation.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import threading
@@ -27,6 +28,7 @@ def _get_client():
         if _api_key is None:
             try:
                 import streamlit as st
+
                 _api_key = st.secrets["GEMINI_API_KEY"]
             except Exception:
                 _api_key = os.environ.get("GEMINI_API_KEY")
@@ -40,10 +42,6 @@ def _get_client():
 
 
 # 구조화 모델
-class TranslationResult(BaseModel):
-    translated_text: str
-
-
 class ImageTranslation(BaseModel):
     original: str
     translated: str
@@ -55,6 +53,10 @@ logging.basicConfig(
 )
 
 
+class ParagraphMismatchError(Exception):
+    """Raised when the translated paragraph count doesn't match the source."""
+
+
 def retry_with_delay(func, *args, max_retries=5, default_delay=10, **kwargs):
     for attempt in range(max_retries):
         try:
@@ -62,6 +64,10 @@ def retry_with_delay(func, *args, max_retries=5, default_delay=10, **kwargs):
                 f"Attempt {attempt + 1}/{max_retries} for function {func.__name__}"
             )
             return func(*args, **kwargs)
+        except ParagraphMismatchError as e:
+            logging.warning(
+                f"Paragraph count mismatch (attempt {attempt + 1}): {e}. Retrying..."
+            )
         except ClientError as e:
             if e.code == 429 and e.status == "RESOURCE_EXHAUSTED":
                 retry_delay = default_delay
@@ -90,19 +96,28 @@ def retry_with_delay(func, *args, max_retries=5, default_delay=10, **kwargs):
 
 
 def translate_text_with_gemini(
-    text: str,
+    paragraphs: list[str],
     model_name: str = DEFAULT_GEMINI_MODEL_NAME,
-) -> str:
+) -> list[str]:
+    """Translate a list of paragraphs, returning a list of the same length."""
+    expected_len = len(paragraphs)
+    input_json = json.dumps(paragraphs, ensure_ascii=False)
+
     def call_gemini_api():
         response = _get_client().models.generate_content(
             model=model_name,
-            contents=[TEXT_TRANSLATION_PROMPT, text],
+            contents=[TEXT_TRANSLATION_PROMPT, input_json],
             config={
                 "response_mime_type": "application/json",
-                "response_schema": TranslationResult,
+                "response_schema": list[str],
             },
         )
-        return response.parsed.translated_text
+        result: list[str] = response.parsed
+        if len(result) != expected_len:
+            raise ParagraphMismatchError(
+                f"Expected {expected_len} paragraphs but got {len(result)}"
+            )
+        return result
 
     return retry_with_delay(call_gemini_api)
 

--- a/utils/translation_runner.py
+++ b/utils/translation_runner.py
@@ -1,22 +1,33 @@
 """Run translation over chunks: sequential (benchmark only) and parallel (app)."""
 
+import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from utils.config import DEFAULT_GEMINI_MODEL_NAME
 from utils.translation import translate_image_with_gemini, translate_text_with_gemini
 
+log = logging.getLogger(__name__)
+
 
 def _translate_single_chunk(chunk: dict, model_name: str) -> dict:
-    """Translate one chunk in-place (sets chunk['translated']) and return the same chunk."""
+    """Translate one chunk (sets chunk['translated']) and return it.
+
+    TEXT chunks: content is list[str], translated becomes list[str] of same length.
+    FIGURE chunks: content is PIL image, translated becomes list[ImageTranslation].
+    """
     if chunk["type"] == "TEXT":
-        chunk["translated"] = translate_text_with_gemini(
-            chunk["content"], model_name
+        paragraphs: list[str] = chunk["content"]
+        translated = translate_text_with_gemini(paragraphs, model_name)
+        log.info(
+            "TEXT chunk translated: %d paragraphs in -> %d out",
+            len(paragraphs),
+            len(translated),
         )
+        chunk["translated"] = translated
     elif chunk["type"] == "FIGURE":
-        translated_pairs = translate_image_with_gemini(
+        chunk["translated"] = translate_image_with_gemini(
             chunk["content"], model_name
         )
-        chunk["translated"] = translated_pairs
     return chunk
 
 


### PR DESCRIPTION
## Summary

번역 과정에서 단락 경계가 합쳐지는 문제를 해결하기 위해, TEXT 번역 파이프라인을 **문자열 기반에서 단락 리스트 기반으로 변경**했습니다.  
이제 원문 `.docx`의 단락 수(빈 줄 포함)와 번역 결과 단락 수를 1:1로 맞추는 가드레일이 적용됩니다.

---

## What Changed

### Before

* TEXT 청크를 `"\n".join(...)`으로 합쳐 하나의 문자열로 번역 요청
* 모델 응답도 단일 문자열로 받아 `split("\n")`로 다시 분해
* 모델 출력 줄바꿈이 흔들리면 단락 수 mismatch 발생 가능
* 번역 결과 테이블에서 이미지 객체(PIL) 직렬화 이슈 발생 가능

### After

* TEXT 청크를 `list[str]` 형태로 유지한 채 번역 요청
* Gemini Structured Output으로 `list[str]`를 직접 수신
* 응답 길이와 입력 길이를 비교해 mismatch 시 재시도
* 문서 생성 시 `split("\n")` 없이 단락 리스트를 그대로 반영
* 결과 테이블은 표시용 문자열로 변환해 직렬화 안정성 확보
* 진행률은 긴 작업인 **번역 단계**에만 유지

---

## Key changes

* `utils/chunker.py`
  * TEXT 청크의 `content`를 `str`에서 `list[str]`로 변경
* `utils/config.py`
  * TEXT 프롬프트를 배열 입력/동일 길이 배열 출력 규칙으로 정렬
* `utils/translation.py`
  * `translate_text_with_gemini(paragraphs: list[str]) -> list[str]`로 시그니처 변경
  * `response_schema=list[str]` 적용
  * 길이 불일치 가드(`ParagraphMismatchError`) 및 재시도 처리 추가
* `utils/translation_runner.py`
  * TEXT 번역 경로를 새 계약(`list[str]`)에 맞게 반영
  * chunk 단위 paragraph in/out 로그 추가
* `app.py`
  * doc build에서 TEXT를 단락 리스트 기반으로 직접 반영
  * FIGURE 렌더링 루프 단순화
  * 결과 테이블을 직렬화 가능한 표시용 데이터로 변환
  * 빠르게 지나가는 parse/build 진행률은 제거하고 번역 진행률만 유지