### PR TITLE
Improve translation reliability with split fallback retries

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,4 +147,4 @@ if st.session_state.translated:
                 row["content"] = "(image)"
                 row["translated"] = str(c.get("translated", ""))
             display_rows.append(row)
-        st.dataframe(pd.DataFrame(display_rows), use_container_width=True)
+        st.dataframe(pd.DataFrame(display_rows), width="stretch")

--- a/tests/test_translation_flow.py
+++ b/tests/test_translation_flow.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import patch
+
+from utils import translation
+
+
+class TestTranslateTextFlow(unittest.TestCase):
+    def test_empty_paragraphs_returns_empty_list(self):
+        result = translation.translate_text_with_gemini([])
+        self.assertEqual(result, [])
+
+    def test_uses_5_retries_for_small_batch(self):
+        paragraphs = ["a", "b", "c"]
+
+        with patch(
+            "utils.translation._translate_text_batch_with_retry",
+            return_value=["ja-a", "ja-b", "ja-c"],
+        ) as mock_batch:
+            result = translation.translate_text_with_gemini(paragraphs, model_name="m")
+
+        self.assertEqual(result, ["ja-a", "ja-b", "ja-c"])
+        mock_batch.assert_called_once_with(paragraphs, model_name="m", max_retries=5)
+
+    def test_uses_3_retries_for_large_batch(self):
+        paragraphs = [f"p{i}" for i in range(80)]
+        translated = [f"ja-{i}" for i in range(80)]
+
+        with patch(
+            "utils.translation._translate_text_batch_with_retry",
+            return_value=translated,
+        ) as mock_batch:
+            result = translation.translate_text_with_gemini(paragraphs, model_name="m")
+
+        self.assertEqual(result, translated)
+        mock_batch.assert_called_once_with(paragraphs, model_name="m", max_retries=3)
+
+    def test_splits_and_merges_when_batch_retries_exhausted(self):
+        paragraphs = [f"p{i}" for i in range(6)]
+
+        def fake_batch(sub_paragraphs, model_name, max_retries):
+            # Force split on the original batch, then succeed on child batches.
+            if len(sub_paragraphs) == 6:
+                raise RuntimeError("Failed to execute call_gemini_api after retries")
+            return [f"ja-{p}" for p in sub_paragraphs]
+
+        with patch(
+            "utils.translation._translate_text_batch_with_retry",
+            side_effect=fake_batch,
+        ) as mock_batch:
+            result = translation.translate_text_with_gemini(paragraphs, model_name="m")
+
+        self.assertEqual(result, [f"ja-p{i}" for i in range(6)])
+
+        # 1st call fails at len=6, then split calls len=3 and len=3.
+        call_lengths = [len(call.args[0]) for call in mock_batch.call_args_list]
+        self.assertEqual(call_lengths, [6, 3, 3])
+
+    def test_raises_when_single_paragraph_keeps_failing(self):
+        with patch(
+            "utils.translation._translate_text_batch_with_retry",
+            side_effect=RuntimeError("Failed to execute call_gemini_api after retries"),
+        ):
+            with self.assertRaises(RuntimeError):
+                translation.translate_text_with_gemini(["only-one"], model_name="m")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/translation.py
+++ b/utils/translation.py
@@ -57,6 +57,31 @@ class ParagraphMismatchError(Exception):
     """Raised when the translated paragraph count doesn't match the source."""
 
 
+def _translate_text_batch_with_retry(
+    paragraphs: list[str], model_name: str, max_retries: int
+) -> list[str]:
+    expected_len = len(paragraphs)
+    input_json = json.dumps(paragraphs, ensure_ascii=False)
+
+    def call_gemini_api():
+        response = _get_client().models.generate_content(
+            model=model_name,
+            contents=[TEXT_TRANSLATION_PROMPT, input_json],
+            config={
+                "response_mime_type": "application/json",
+                "response_schema": list[str],
+            },
+        )
+        result: list[str] = response.parsed
+        if len(result) != expected_len:
+            raise ParagraphMismatchError(
+                f"Expected {expected_len} paragraphs but got {len(result)}"
+            )
+        return result
+
+    return retry_with_delay(call_gemini_api, max_retries=max_retries)
+
+
 def retry_with_delay(func, *args, max_retries=5, default_delay=10, **kwargs):
     for attempt in range(max_retries):
         try:
@@ -99,27 +124,33 @@ def translate_text_with_gemini(
     paragraphs: list[str],
     model_name: str = DEFAULT_GEMINI_MODEL_NAME,
 ) -> list[str]:
-    """Translate a list of paragraphs, returning a list of the same length."""
-    expected_len = len(paragraphs)
-    input_json = json.dumps(paragraphs, ensure_ascii=False)
+    """Translate a list of paragraphs, returning a list of the same length.
 
-    def call_gemini_api():
-        response = _get_client().models.generate_content(
-            model=model_name,
-            contents=[TEXT_TRANSLATION_PROMPT, input_json],
-            config={
-                "response_mime_type": "application/json",
-                "response_schema": list[str],
-            },
+    If a large chunk keeps failing with paragraph-count mismatch, split it into
+    smaller batches and retry recursively so one bad chunk does not stall the
+    whole translation run for too long.
+    """
+    if not paragraphs:
+        return []
+
+    max_retries = 3 if len(paragraphs) >= 80 else 5
+    try:
+        return _translate_text_batch_with_retry(
+            paragraphs, model_name=model_name, max_retries=max_retries
         )
-        result: list[str] = response.parsed
-        if len(result) != expected_len:
-            raise ParagraphMismatchError(
-                f"Expected {expected_len} paragraphs but got {len(result)}"
-            )
-        return result
-
-    return retry_with_delay(call_gemini_api)
+    except RuntimeError:
+        if len(paragraphs) <= 1:
+            raise
+        mid = len(paragraphs) // 2
+        logging.warning(
+            "Falling back to split translation for %d paragraphs (%d + %d).",
+            len(paragraphs),
+            mid,
+            len(paragraphs) - mid,
+        )
+        left = translate_text_with_gemini(paragraphs[:mid], model_name=model_name)
+        right = translate_text_with_gemini(paragraphs[mid:], model_name=model_name)
+        return left + right
 
 
 def translate_image_with_gemini(


### PR DESCRIPTION
## Summary

문단 수 불일치가 반복될 때 전체 번역이 오래 정체되는 문제를 줄이기 위해, TEXT 번역에 **분할 폴백(recursive split fallback)을** 추가했습니다.  
큰 청크 실패 시 같은 요청을 장시간 반복하는 대신, 더 작은 배치로 분해해 진행을 이어갑니다.

또한 실제 API 호출 없이 흐름을 검증할 수 있도록 **mock 기반 단위 테스트**를 추가했습니다.

---

## What Changed

### Before

* 큰 TEXT 청크에서 `ParagraphMismatchError`가 반복되면 동일 청크 재시도에 시간이 길게 소요됨
* 실패 청크 하나가 전체 체감 시간을 크게 늘릴 수 있음
* Streamlit에서 `use_container_width` deprecation 경고가 노출됨
* 분할 폴백 흐름을 자동 검증하는 단위 테스트가 없음

### After

* TEXT 청크 번역 호출을 배치 함수로 분리
* 큰 청크(80+ 문단)는 재시도 횟수를 낮춰 장기 대기 구간 축소
* 재시도 소진 시 청크를 반으로 나눠 재귀적으로 번역 후 순서대로 병합
* `st.dataframe(..., use_container_width=True)`를 `width='stretch'`로 교체
* `unittest + mock`으로 재시도/분할/병합/실패 전파 흐름 테스트 추가

---

## Fallback Flow (Visualization)

```mermaid
flowchart TD
  A["TEXT 청크 번역 시도"] --> B{"문단 수 일치?"}
  B -- Yes --> C["번역 결과 반환"]
  B -- No --> D{"재시도 남음?"}
  D -- Yes --> A
  D -- No --> E{"문단 수 > 1?"}
  E -- No --> F["최종 실패 전파"]
  E -- Yes --> G["청크를 Left/Right로 분할"]
  G --> H["Left 번역"]
  G --> I["Right 번역"]
  H --> J["결과 병합 (Left + Right)"]
  I --> J
  J --> C
```

---

## Key changes

* `utils/translation.py`
  * `_translate_text_batch_with_retry(...)` 분리
  * `translate_text_with_gemini(...)`에 분할 폴백(순차) 추가
  * 큰 청크의 재시도 횟수 조정(80+ 문단)
* `app.py`
  * `st.dataframe` 인자 deprecation 대응 (`width='stretch'`)
* `tests/test_translation_flow.py`
  * mock 기반 단위 테스트 5종 추가
  * small/large 배치 재시도 정책 검증
  * 재시도 소진 시 split fallback 및 merge 순서 검증
  * 단일 문단 최종 실패 전파 검증

---

## Test plan

- [x] `python -m py_compile app.py utils/translation.py`
- [x] 변경 파일 lint/진단 확인 (`app.py`, `utils/translation.py`)
- [x] `python -m unittest tests/test_translation_flow.py -v`
- [x] 번역 실패 로그 패턴 기준으로 분할 폴백 경로 코드 검토