### PR TITLE
Metrics: phase seed + workers query-param + Sheets sink pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,5 @@ cython_debug/
 .pypirc
 
 # streamlit configuration folder
-.streamlit/
+.streamlit/*
+!.streamlit/secrets.example.toml

--- a/.streamlit/secrets.example.toml
+++ b/.streamlit/secrets.example.toml
@@ -1,0 +1,27 @@
+# Copy this file to .streamlit/secrets.toml and fill in real values.
+# .streamlit/secrets.toml is git-ignored; this *.example.toml is not.
+
+GEMINI_API_KEY = "your_gemini_api_key"
+
+# Metrics sink (optional). Set metrics_enabled = true and the
+# gcp_service_account / metrics_sheet_id below to push run metrics to
+# Google Sheets. With metrics_enabled = false (default) the metrics code
+# path falls through to a no-op collector.
+metrics_enabled = false
+metrics_sheet_id = "1AbCdEf...replace-with-your-spreadsheet-id"
+
+[gcp_service_account]
+type = "service_account"
+project_id = "your-gcp-project"
+private_key_id = "..."
+private_key = """-----BEGIN PRIVATE KEY-----
+...
+-----END PRIVATE KEY-----
+"""
+client_email = "metrics-writer@your-gcp-project.iam.gserviceaccount.com"
+client_id = "..."
+auth_uri = "https://accounts.google.com/o/oauth2/auth"
+token_uri = "https://oauth2.googleapis.com/token"
+auth_provider_x509_cert_url = "https://www.googleapis.com/oauth2/v1/certs"
+client_x509_cert_url = "https://www.googleapis.com/robot/v1/metadata/x509/metrics-writer%40your-gcp-project.iam.gserviceaccount.com"
+universe_domain = "googleapis.com"

--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -13,7 +15,20 @@ from utils import (
     parse_docx_with_images,
     translate_chunks_parallel,
 )
-from utils.config import TRANSLATION_MAX_WORKERS
+from utils.config import METRICS_ENABLED_ENV_VAR, TRANSLATION_MAX_WORKERS
+from utils.metrics import (
+    PHASE_BUILDING_DOC,
+    PHASE_TRANSLATING,
+    STATUS_ERROR,
+    STATUS_OK,
+    MetricsCollector,
+    NullMetricsCollector,
+    NullSink,
+    set_active_collector,
+)
+from utils.metrics_sheets import build_sheets_sink_from_secrets
+
+log = logging.getLogger(__name__)
 
 # 초기 상태
 if "translated" not in st.session_state:
@@ -88,6 +103,77 @@ def build_doc_from_translated_chunks(doc, chunks):
                 doc.add_paragraph_with_justify(f"{p.original}: {p.translated}")
 
 
+def _metrics_enabled() -> bool:
+    """Env var first, then st.secrets — both falsy by default."""
+    env = os.environ.get(METRICS_ENABLED_ENV_VAR, "").strip().lower()
+    if env in ("1", "true", "yes", "on"):
+        return True
+    if env in ("0", "false", "no", "off"):
+        return False
+    try:
+        return bool(st.secrets.get("metrics_enabled", False))
+    except Exception:
+        return False
+
+
+def _build_collector(uploaded_file, chunks):
+    """Instantiate a real collector when secrets/flag align; Null otherwise.
+
+    The collector itself is harmless to construct (no IO until start()),
+    but we still short-circuit to NullMetricsCollector when disabled so
+    the sampler/flusher threads aren't spun up for nothing.
+    """
+    if not _metrics_enabled():
+        return NullMetricsCollector()
+    sink = build_sheets_sink_from_secrets()
+    if sink is None:
+        log.info("[metrics] sheets sink unavailable; using NullSink locally")
+        sink = NullSink()
+    collector = MetricsCollector(sink)
+
+    text_chunks = [c for c in chunks if c["type"] == "TEXT"]
+    figure_chunks = [c for c in chunks if c["type"] == "FIGURE"]
+    chunk_sizes = [len(c["content"]) for c in text_chunks]
+    total_input_chars = sum(
+        len(p) for c in text_chunks for p in c["content"]
+    )
+
+    file_size = 0
+    doc_name = ""
+    if uploaded_file is not None:
+        doc_name = getattr(uploaded_file, "name", "") or ""
+        size = getattr(uploaded_file, "size", None)
+        if isinstance(size, int):
+            file_size = size
+
+    collector.record(
+        doc_name=doc_name,
+        file_size_bytes=file_size,
+        n_chunks=len(chunks),
+        n_text_chunks=len(text_chunks),
+        n_figure_chunks=len(figure_chunks),
+        n_paragraphs=sum(chunk_sizes),
+        n_images=len(figure_chunks),
+        chunk_size_max=max(chunk_sizes) if chunk_sizes else 0,
+        chunk_size_avg=(sum(chunk_sizes) / len(chunk_sizes)) if chunk_sizes else 0.0,
+        total_input_chars=total_input_chars,
+        workers=TRANSLATION_MAX_WORKERS,
+        model_name=DEFAULT_GEMINI_MODEL_NAME,
+    )
+    return collector
+
+
+def _count_output_chars(translated_chunks):
+    total = 0
+    for c in translated_chunks:
+        if c["type"] == "TEXT":
+            total += sum(len(p) for p in c.get("translated", []) or [])
+        elif c["type"] == "FIGURE":
+            for item in c.get("translated", []) or []:
+                total += len(getattr(item, "translated", "") or "")
+    return total
+
+
 # 번역 실행
 def run_translation():
     chunks = st.session_state.chunked_elements
@@ -100,21 +186,42 @@ def run_translation():
             text=f"🔄 번역 중... {completed} / {total_n} 청크 완료",
         )
 
-    progress_placeholder.progress(0, text=f"🔄 번역 중... 0 / {total} 청크 완료")
-    translated_chunks = translate_chunks_parallel(
-        chunks,
-        model_name=DEFAULT_GEMINI_MODEL_NAME,
-        max_workers=TRANSLATION_MAX_WORKERS,
-        progress_callback=progress_cb,
-    )
-    st.session_state.chunked_elements = translated_chunks
-    build_doc_from_translated_chunks(doc, translated_chunks)
+    collector = _build_collector(uploaded_file, chunks)
+    set_active_collector(collector)
+    collector.start()
 
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".docx") as tmp_file:
-        doc.save(tmp_file.name)
-        st.session_state.output_path = tmp_file.name
+    status = STATUS_ERROR
+    error: BaseException | None = None
+    try:
+        progress_placeholder.progress(0, text=f"🔄 번역 중... 0 / {total} 청크 완료")
+        collector.set_phase(PHASE_TRANSLATING)
+        translated_chunks = translate_chunks_parallel(
+            chunks,
+            model_name=DEFAULT_GEMINI_MODEL_NAME,
+            max_workers=TRANSLATION_MAX_WORKERS,
+            progress_callback=progress_cb,
+            metrics_collector=collector,
+        )
+        st.session_state.chunked_elements = translated_chunks
 
-    st.session_state.translated = True
+        collector.set_phase(PHASE_BUILDING_DOC)
+        build_doc_from_translated_chunks(doc, translated_chunks)
+        collector.record(total_output_chars=_count_output_chars(translated_chunks))
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".docx") as tmp_file:
+            doc.save(tmp_file.name)
+            st.session_state.output_path = tmp_file.name
+
+        st.session_state.translated = True
+        status = STATUS_OK
+    except BaseException as e:
+        error = e
+        raise
+    finally:
+        try:
+            collector.stop_and_finalize(status, error=error)
+        except Exception:
+            log.exception("[metrics] stop_and_finalize raised; ignoring")
 
 
 # 번역 시작 버튼

--- a/app.py
+++ b/app.py
@@ -50,6 +50,20 @@ st.markdown(
     f":material/smart_toy: AI 모델: :blue-badge[{DEFAULT_GEMINI_MODEL_DISPLAY_NAME}]"
 )
 
+def _resolve_workers() -> int:
+    """Hidden tuning knob via ?workers=N query param; falls back to default."""
+    raw = st.query_params.get("workers")
+    if raw is None:
+        return TRANSLATION_MAX_WORKERS
+    try:
+        n = int(raw)
+    except (ValueError, TypeError):
+        return TRANSLATION_MAX_WORKERS
+    return max(1, min(n, 32))
+
+
+workers = _resolve_workers()
+
 # 파일 업로드
 uploaded_file = st.file_uploader("📤 번역할 .docx 파일을 업로드하세요", type=["docx"])
 
@@ -116,7 +130,7 @@ def _metrics_enabled() -> bool:
         return False
 
 
-def _build_collector(uploaded_file, chunks):
+def _build_collector(uploaded_file, chunks, workers):
     """Instantiate a real collector when secrets/flag align; Null otherwise.
 
     The collector itself is harmless to construct (no IO until start()),
@@ -157,7 +171,7 @@ def _build_collector(uploaded_file, chunks):
         chunk_size_max=max(chunk_sizes) if chunk_sizes else 0,
         chunk_size_avg=(sum(chunk_sizes) / len(chunk_sizes)) if chunk_sizes else 0.0,
         total_input_chars=total_input_chars,
-        workers=TRANSLATION_MAX_WORKERS,
+        workers=workers,
         model_name=DEFAULT_GEMINI_MODEL_NAME,
     )
     return collector
@@ -175,7 +189,7 @@ def _count_output_chars(translated_chunks):
 
 
 # 번역 실행
-def run_translation():
+def run_translation(workers: int):
     chunks = st.session_state.chunked_elements
     total = len(chunks)
     doc = create_japanese_patent_docx()
@@ -186,19 +200,18 @@ def run_translation():
             text=f"🔄 번역 중... {completed} / {total_n} 청크 완료",
         )
 
-    collector = _build_collector(uploaded_file, chunks)
+    collector = _build_collector(uploaded_file, chunks, workers)
     set_active_collector(collector)
-    collector.start()
+    collector.start(initial_phase=PHASE_TRANSLATING)
 
     status = STATUS_ERROR
     error: BaseException | None = None
     try:
         progress_placeholder.progress(0, text=f"🔄 번역 중... 0 / {total} 청크 완료")
-        collector.set_phase(PHASE_TRANSLATING)
         translated_chunks = translate_chunks_parallel(
             chunks,
             model_name=DEFAULT_GEMINI_MODEL_NAME,
-            max_workers=TRANSLATION_MAX_WORKERS,
+            max_workers=workers,
             progress_callback=progress_cb,
             metrics_collector=collector,
         )
@@ -226,7 +239,7 @@ def run_translation():
 
 # 번역 시작 버튼
 if uploaded_file and not st.session_state.translated:
-    st.button("🚀 번역 시작", on_click=run_translation)
+    st.button("🚀 번역 시작", on_click=run_translation, args=(workers,))
 
 # 번역 완료 후 결과
 if st.session_state.translated:

--- a/docs/PLAN_metrics_to_sheets.md
+++ b/docs/PLAN_metrics_to_sheets.md
@@ -1,0 +1,297 @@
+# Plan: Streamlit Cloud 인프라 지표를 Google Sheets로 푸시
+
+> **Revision history**
+> - v1: 초안 (작성)
+> - v2: codex 1차 리뷰 반영 — 주기 flush, runs 2-step write, contextvars 제거, 데이터 모델 보강, 1차 PR 범위 축소
+> - v3: 사용자 직접 개정 — sampler/flusher 분리, lock 순서 1차안, `n_failed_chunks` 위치 확정 (runner), `running` 해석 약화 (stale row), bounded buffer 언급, 검증 시나리오 추가
+> - v4: codex 2차 리뷰 반영 — `_SheetsSink` IO lock 명시, `MAX_BUFFER_ROWS` 폐기 정책 구체화, lock 획득 순서 문서화, 429 retry 카운팅 의미 정정, recursive split fallback 의 metrics 전달 명시, runner fail-fast 정책 결정, gspread find 컬럼 한정, psutil prime 처리, 작업 추정 9-12h 로 상향. **conditional go → go.**
+> - v4.1: codex 3차 sanity check 반영 — finalize 시 `_sink_io_lock` 획득에 timeout(3.0s) + skip + warning 추가. **최종 go.**
+
+## 0. 운영 전제 (명시)
+
+- 솔로 사용자, 단일 세션, 동시 1건 번역만 발생한다고 가정.
+- 다중 사용자 / 다중 탭 / 동시 번역은 1차 범위 밖. module-level global collector + lock 으로 충분.
+- 민감정보 마스킹은 의도적으로 하지 않음 (개인 프로젝트, 문서 식별이 분석에 도움). 단 `error_msg`는 분석 편의로 `error_type` + `error_short`(앞 N자) 으로만 분리.
+
+## 1. 배경 / 목적
+
+- Streamlit Cloud 컨테이너는 트래픽 없을 때 sleep 되고 in-memory/로컬 파일 모두 휘발.
+- 실시간 관찰 없이도 "어떤 문서를 몇 워커로 돌렸을 때 RAM 피크가 얼마였는지", "429 retry가 얼마나 났는지", "OOM으로 죽었는지"를 사후 분석 가능하게 한다.
+- 2차 목표: `TRANSLATION_MAX_WORKERS` 튜닝 근거 데이터 축적 (현재 8 → 12/16 실험).
+- **OOM 등으로 프로세스가 죽어도 직전 샘플이 남아 있어야 한다** — 이게 v1 대비 가장 큰 설계 변경.
+- 단, `status=running` 으로 남은 row 는 "abnormal termination" 의 강한 증거가 아니라 **"finalize 미확인 / stale running row"** 로 해석한다. OOM 외에도 Sheets update 실패, Streamlit rerun, 배포 재시작 모두 같은 흔적을 남기기 때문. 정확한 원인 추정은 `samples` 의 마지막 `sampled_at` + Cloud 로그 + run duration 추정을 같이 봐야 한다.
+
+## 2. Scope
+
+### In-scope (1차 PR)
+- 번역 1회 = `runs` 시트 row 1개 (시작 시 `running` 으로 append, 종료 시 update)
+- `samples` 시트에 주기적 buffer flush (~30s 간격, 마지막 잔여분도 flush)
+- retry / split fallback / API call 카운터를 명시적 `incr()` 로 수집
+- `translating`, `building_doc` 두 phase만 정확히 기록 (parsing은 후순위)
+- best-effort: Sheets 호출 실패해도 번역 결과에는 영향 없음
+
+### Out-of-scope (후속 PR로 분리)
+- Discord webhook 알림
+- Sheets 차트 자동 셋업 (수동 1회면 충분)
+- `parsing` phase 정확 측정 (현재 앱 구조상 버튼 클릭 전에 파싱이 끝나므로 모호함)
+- 다중 사용자 / 다중 세션 동시 실행 대응
+- 시트 retention 자동화 (월별 탭 분할 등) — 일단 단일 시트 운영, 커지면 후속
+
+## 3. 데이터 모델
+
+`run_id`(UUID4) 로 join.
+
+### `runs` 시트
+
+번역 시작 시점에 `status=running` 으로 1행 append. 종료 시점에 `run_id` 로 찾아 같은 행을 update.
+종료 update 실패 케이스도 대비해 별도 `runs_events` 시트로 분리할지는 1차에서 미적용 (단일 row update 실패하면 row가 그대로 `running` 으로 남는 것을 "abnormal termination" 신호로 해석).
+
+| 컬럼 | 타입 | 비고 |
+|---|---|---|
+| `run_id` | string | UUID4 |
+| `started_at` | ISO8601 UTC | append 시점 |
+| `ended_at` | ISO8601 UTC \| empty | running 동안 비움 |
+| `duration_total_s` | float \| empty | |
+| `duration_translate_s` | float \| empty | translating phase만 |
+| `duration_build_doc_s` | float \| empty | building_doc phase만 |
+| `doc_name` | string | 원본 파일명 그대로 (마스킹 X) |
+| `file_size_bytes` | int | uploaded_file 크기 |
+| `n_paragraphs` | int | parsed paragraphs 총수 |
+| `n_images` | int | figure 요소 총수 |
+| `n_chunks` | int | |
+| `n_text_chunks` | int | |
+| `n_figure_chunks` | int | |
+| `chunk_size_max` | int | TEXT chunk 중 최대 paragraph 수 |
+| `chunk_size_avg` | float | |
+| `total_input_chars` | int | TEXT chunk 합산 (이미지 제외) |
+| `total_output_chars` | int \| empty | 번역 결과 합산, 실패 시 비움 |
+| `workers` | int | `TRANSLATION_MAX_WORKERS` |
+| `model_name` | string | `gemini-2.5-flash` |
+| `sample_interval_s` | float | `METRICS_SAMPLE_INTERVAL_S` |
+| `peak_ram_mb` | float \| empty | samples 의 max |
+| `avg_process_cpu_pct` | float \| empty | samples 평균 (단일 코어 기준 100%, 멀티 코어면 > 100% 가능) |
+| `peak_process_threads` | int \| empty | |
+| `n_text_api_calls` | int | 성공/실패 무관 attempt 합 |
+| `n_image_api_calls` | int | |
+| `n_429_errors` | int | 429를 받은 횟수 (retry 여부 무관) |
+| `n_429_retries` | int | 실제로 retry 수행한 횟수 |
+| `n_mismatch_errors` | int | ParagraphMismatchError 발생 횟수 |
+| `n_mismatch_retries` | int | mismatch 후 실제 retry 수행 |
+| `n_split_fallbacks` | int | split fallback 진입 횟수 |
+| `n_failed_chunks` | int | 모든 retry/fallback 후에도 실패한 chunk 수 |
+| `status` | enum | `running` / `ok` / `error` |
+| `error_type` | string \| empty | `RuntimeError` 등 클래스명 |
+| `error_short` | string \| empty | 방어적으로 `str(e)` 시도, 실패 시 `repr(e)[:500]`. 줄바꿈/탭은 공백 치환 후 500자 절단 |
+| `app_version` | string | env `APP_VERSION` → git SHA → `"unknown"` 순으로 fallback |
+| `n_dropped_samples` | int | sampler buffer cap 초과로 drop 한 sample 수 (정상 시 0) |
+| `was_append_only` | bool | `running` row append 자체가 실패해 finalize 가 append-only 로 종료 row 를 새로 쓴 경우 true |
+
+### `samples` 시트
+
+주기적으로 buffer 를 batch append. row 순서 꼬임 대비해 절대 timestamp 컬럼 포함.
+
+| 컬럼 | 타입 |
+|---|---|
+| `run_id` | string |
+| `sampled_at` | ISO8601 UTC |
+| `t_offset_s` | float (run started_at 기준) |
+| `ram_mb` | float (`process.memory_info().rss / 1024**2`) |
+| `process_cpu_pct` | float (`process.cpu_percent(interval=None)`, 워밍업 1회 후) |
+| `process_threads` | int (`process.num_threads()`) |
+| `phase` | enum (`translating` / `building_doc`) |
+
+## 4. 아키텍처 / 데이터 흐름
+
+```
+[run_translation() in app.py]
+        |
+        v
+[MetricsCollector(run_id, sheet_client)]
+[collector.start()]
+   ├─> 백그라운드 sampler thread (daemon)
+   │     매 sample_interval_s 마다 psutil 읽어 buffer 에만 append
+   │     (절대 직접 Sheets 호출 X — Sheets 응답 지연이 sampling을 막으면 안 됨)
+   │
+   ├─> 백그라운드 flusher thread (daemon, 별도)
+   │     매 FLUSH_INTERVAL_S 또는 buffer >= FLUSH_BATCH_SIZE 시 깨어남
+   │     buffer swap 후 samples 시트로 batch append
+   │     Sheets 호출 실패 시 swapped batch만 폐기 (bounded — 무한 보존 안 함, 다음 cycle 정상 진행)
+   │
+   └─> 번역 시작 직전 runs 시트에 status=running row append (1회)
+        |
+   [translate_chunks_parallel(chunks, ..., metrics_collector=collector)]   # 명시적 인자 전달
+        ├─> worker thread 내부에서 translation.py 호출
+        │     retry / split / api_call 시점에 collector.incr(...)
+        │     (collector는 threading.Lock 으로 보호된 dict 카운터)
+        |
+   [build_doc_from_translated_chunks(...)]
+        |
+        v
+[finally: collector.stop_and_finalize(status, error)]
+        ├─> sampler/flusher Event.set, 각각 join (timeout 1.0s)
+        ├─> 남은 buffer 강제 flush 1회 (lock 짧게 잡고 swap → swap 본을 락 밖에서 push)
+        └─> runs 시트 row update (run_id 로 찾아서 ended_at, duration*, peak_*, n_* 등 update)
+```
+
+### 핵심 결정
+
+- **collector 보유 방식: app.py 에서 인스턴스 생성 → `translate_chunks_parallel` 인자로 명시 전달**
+  - contextvars 는 ThreadPoolExecutor worker thread 로 자동 전파되지 않으므로 사용하지 않음.
+  - `_translate_single_chunk` 시그니처에 `metrics: MetricsCollector | None = None` 추가.
+  - `translation.py` 의 `retry_with_delay` / `translate_text_with_gemini` 가 `metrics` 를 받아 `incr()` 호출.
+  - **recursive split fallback (`translate_text_with_gemini` 내부 left/right 재귀 호출) 에도 동일 `metrics` 인자 명시 전달 필수.** 누락 시 split 이후 API call / 429 / mismatch 가 전부 누락됨.
+- **collector가 None 일 때 no-op**: `NullMetricsCollector` 가 default. 반드시 전체 인터페이스 (`start`, `stop_and_finalize`, `incr`, `set_phase`, `record`, `record_failed_chunk`) 를 동일 시그니처로 구현해야 호출부에 None 체크가 없어진다.
+- **flush 주기**: `FLUSH_INTERVAL_S = 30`, `FLUSH_BATCH_SIZE = 30` 중 먼저 도달하는 쪽. 1.5s interval 기준 30초면 ~20 rows라 사실상 시간 조건이 먼저 발화.
+- **buffer cap 정책 (`MAX_BUFFER_ROWS = 2000`)**: sampler 가 buffer 에 append 하기 직전 길이 확인 → cap 초과 시 **drop-oldest** (head 에서 가장 오래된 1행 제거 후 append). drop 발생 시 collector 내부 카운터 `n_dropped_samples` 증가, 종료 시 `runs.n_dropped_samples` 컬럼 (※ §3 데이터 모델에 추가 필요) 으로 기록. 의미: Sheets 가 장시간 hang / flusher 사망 같은 비정상 상황에서도 메모리는 bounded.
+- **lock 순서 규칙 (deadlock 회피 절대 순서)**:
+  1. `_counter_lock` (incr / counters snapshot 용, in-memory dict)
+  2. `_buffer_lock` (samples buffer / phase 읽기·쓰기 용, in-memory list/scalar)
+  3. `_sink_io_lock` (`_SheetsSink` 내부, gspread 호출 직렬화 용)
+  - 한 함수가 동시에 둘 이상 잡지 않는 것이 기본. 잡아야 할 경우 위 순서로만 acquire.
+  - lock 1, 2 안에서는 **IO 호출 금지** (lock 들고 Sheets 호출 → 다른 thread 가 같은 lock 으로 막힘).
+  - sampler/flusher 둘 다 `incr` 와 buffer swap 시 짧게 잡고 즉시 해제. Sheets 호출은 반드시 lock 밖.
+- **`_SheetsSink` IO lock**: `_SheetsSink` 가 내부에서 `_sink_io_lock` 보유. flusher 의 주기 flush 와 finalize 의 final flush + runs row update 가 동시에 같은 gspread client 를 만지지 않도록 모든 sink 호출(`append_samples`, `append_run`, `update_run`) 진입부에서 lock 획득 후 호출, 종료 시 해제. **finalize 는 `stop_and_finalize()` 안에서 (a) flusher Event.set → (b) `flusher.join(timeout=1.0s)` → (c) `_sink_io_lock.acquire(timeout=3.0s)` 시도. 잡으면 final flush + update, 실패하면 (= flusher 가 Sheets IO 에서 hang 중) logging.warning 후 skip** 하여 사용자 페이지 전환을 무한정 막지 않음. skip 된 경우 runs row 는 `running` 으로 남고 `n_dropped_samples` 에는 영향 없음.
+- **`n_failed_chunks` 위치 확정**: `translate_chunks_parallel` 에서 `future.result()` 호출을 try/except 로 감싸 exception 발생 시 `collector.record_failed_chunk()` 호출. translation.py 내부에서는 **카운팅 절대 금지** (중복 방지).
+- **Runner fail-fast 정책 확정**: 1차에서는 첫 chunk 실패 시 즉시 raise 하던 기존 동작 유지. 단, raise 전에 `record_failed_chunk()` 1회 호출. 다른 in-flight future 는 `with ThreadPoolExecutor` context 종료 시 자연스럽게 drain 되며, 그 결과는 무시 (실패한 run 의 partial 결과는 사용하지 않음). drain 중 발생하는 추가 실패는 카운트하지 않음.
+- **429 retry 카운팅 의미**: `n_429_errors` 는 429 catch 시점에 무조건 +1. `n_429_retries` 는 **catch 후 다음 attempt 가 실제로 실행될 때만** +1 (마지막 attempt 의 429 는 retries 에 포함하지 않음). 동일 규칙을 `n_mismatch_errors` / `n_mismatch_retries` 에도 적용.
+- **runs row update 방법**: `gspread` `find` 를 **`run_id` 컬럼 범위로 한정** 해서 호출 (header 매칭 회피). row 가 많아지면 느려질 수 있으므로 시작 시 append 응답에서 row 번호를 받아 collector 인스턴스에 캐시 → finalize 시 캐시된 row 번호로 직접 `update_cells` 호출. `find` 는 캐시 무효 시의 fallback.
+- **`running` append 실패 시 finalize 동작**: `running` 행 append 자체가 실패하면 collector 가 `_running_row = None` 으로 보관. finalize 시 `_running_row is None` 이면 **append-only 로 종료 상태 row 를 새로 1행 append** (status, error_*, ended_at, durations, peak_* 모두 포함). 이 경로는 `runs.was_append_only = True` 플래그로 구분.
+- **sampler/flusher 내부 예외 격리**: 두 thread 함수 모두 최외곽 `while not stop.is_set():` 루프 안에 `try/except Exception: logging.exception(...)` 를 둬서 1회성 예외로 thread 가 죽지 않도록.
+
+## 5. 인증 / Secrets
+
+- `st.secrets["gcp_service_account"]` — GCP service account JSON (TOML 형태).
+- `st.secrets["metrics_sheet_id"]` — 대상 스프레드시트 ID.
+- 스프레드시트 공유: service account 이메일에 Editor 권한.
+- 로컬 dev: `.streamlit/secrets.toml`. `.gitignore` 에 이미 포함되어 있는지 1차 PR 시작 시 1회 확인.
+- `APP_VERSION` env: Streamlit Cloud 에서는 수동 secret 으로 주입 가능. 미설정 시 `subprocess` 로 `git rev-parse --short HEAD` 시도, 실패하면 `"unknown"`.
+
+## 6. 구현 변경점
+
+### 신규 파일
+- `utils/metrics.py`
+  - `MetricsCollector`: start / stop_and_finalize / incr(key, n=1) / set_phase / record(run_meta_fields)
+  - `NullMetricsCollector`: 모든 메서드 no-op (default)
+  - `_SheetsSink`: 시트 클라이언트 + append/update 메서드, 실패 시 logging.exception 후 swallow
+  - 내부 lock 보호 카운터 dict, samples buffer (list)
+  - psutil import 는 함수 안에서 try/except (없을 때 sampler 자체를 비활성)
+
+### 수정 파일
+- `app.py`
+  - `run_translation()` 진입 시 collector 생성, `collector.start()`, status=running row append
+  - `translate_chunks_parallel(..., metrics_collector=collector)` 호출
+  - phase 전환: 번역 시작 직전 `set_phase("translating")`, build_doc 직전 `set_phase("building_doc")`
+  - `try/except/finally` 로 감싸 예외 시 `error_type/error_short` 채워 `stop_and_finalize`
+- `utils/translation_runner.py`
+  - `translate_chunks_parallel(..., metrics_collector=None)` 시그니처 추가
+  - `_translate_single_chunk` 에 collector 전달 (api_call 카운팅은 runner 가 아니라 translation.py 쪽에서 함)
+  - `future.result()` 호출을 try/except 로 감싸 chunk 단위 최종 실패 시 `metrics_collector.record_failed_chunk()` 호출 후 다음 chunk 진행 여부 결정 (1차에서는 단일 chunk 실패 = 전체 실패로 raise 하는 기존 동작 유지)
+- `utils/translation.py`
+  - `_get_collector()` 모듈 함수 또는 인자 전달 — **인자 전달 채택** (테스트성, 명시성)
+  - `retry_with_delay` / `_translate_text_batch_with_retry` / `translate_image_with_gemini` / `translate_text_with_gemini` 시그니처에 `metrics` 추가 (default `NullMetricsCollector()`)
+  - `translate_text_with_gemini` 의 **recursive split fallback (`translate_text_with_gemini(paragraphs[:mid], ..., metrics=metrics)` / `paragraphs[mid:]`) 에도 `metrics` 명시 전달** — 빠뜨리면 split 이후 카운트 누락
+  - 분기점에서 `incr` 호출:
+    - 매 attempt 진입 직전: `n_text_api_calls` 또는 `n_image_api_calls`
+    - 429 catch 시점: `n_429_errors` +1 (무조건)
+    - 429 sleep 종료 후 **다음 attempt 진입이 실제로 일어날 때만**: `n_429_retries` +1 (마지막 attempt 의 429 는 retries 에 포함 X)
+    - ParagraphMismatchError catch: `n_mismatch_errors`. 다음 attempt 가 실제로 일어날 때만: `n_mismatch_retries`
+    - split fallback 진입: `n_split_fallbacks` +1
+    - **`n_failed_chunks` 는 절대 translation.py 에서 incr 하지 않음.** runner 쪽 단일 지점에서만 기록.
+- `utils/config.py`
+  - `METRICS_ENABLED` (default False, env/secrets 로 토글)
+  - `METRICS_SAMPLE_INTERVAL_S = 1.5`
+  - `METRICS_FLUSH_INTERVAL_S = 30`
+  - `METRICS_FLUSH_BATCH_SIZE = 30`
+- `requirements.txt`
+  - `psutil`, `gspread`, `google-auth` 추가
+- `.streamlit/secrets.example.toml` 신규
+
+### 미수정
+- `chunker.py`, `docx_parser.py`: 메트릭 무관.
+- 단, app.py 에서 `n_paragraphs`, `n_images`, `chunk_size_*`, `total_input_chars` 는 이미 파싱된 결과로 계산 가능하므로 collector 외부에서 계산해 `record()` 로 넘김.
+
+## 7. 엣지 케이스 / 리스크
+
+| 상황 | 처리 |
+|---|---|
+| psutil 없음 / metric 권한 부족 | sampler 비활성, runs row 는 그대로 기록 (peak_* 비움) |
+| Sheets 호출 실패 (network/429/auth) | exception swallow + logging. 번역에는 영향 X |
+| service account 미설정 / `METRICS_ENABLED=False` | NullMetricsCollector 로 fall through, 코드 경로 동일 |
+| 번역 도중 예외 | finally 에서 status=`error`, error_type/error_short 채워 update |
+| OOM 으로 프로세스 kill | 직전 flush 분까지 samples 시트에 남고 runs row 는 `running` 으로 영구히 남음 → 추후 분석 시 "abnormal termination" 으로 식별 |
+| Streamlit rerun 으로 collector 재생성 | 모듈 global active collector 가 None 이 아니면 stop 후 교체 |
+| 백그라운드 thread 잔존 | daemon=True + Event stop, join timeout 0.5s |
+| `cpu_percent` 첫 샘플 0 문제 | sampler 시작 시 `process.cpu_percent(interval=None)` 1회 워밍업 호출 후 buffer 에 안 넣음 |
+| `runs` row update 시 row 번호 캐시 무효화 | 1차에는 매 update 시 `find(run_id)` 로 lookup. 성능 문제 시 캐시 |
+| `samples` 시트 row 폭증 | 일단 단일 시트, 분기 시 월별 탭으로 이관 (후속) |
+| Streamlit Cloud 에 `.git` 없음 | env `APP_VERSION` 우선, subprocess 실패 시 `"unknown"` |
+| flusher 가 Sheets 호출 중 hang | sampler 는 영향 없음 (lock 분리). `stop_and_finalize` 의 join timeout 1.0s 로 차단. finalize 는 `_sink_io_lock` 획득 후에만 sink 재호출 (§4 참고) |
+| sampler/flusher 내부 예외 | thread 함수 최외곽 while 안에서 `try/except: logging.exception(...)` 로 감싸 thread 사망 방지 |
+| Sheets hang + 장시간 미flush | sampler buffer 가 `MAX_BUFFER_ROWS = 2000` 초과 시 head drop. `n_dropped_samples` 증가. 메모리는 항상 bounded |
+| `running` append 자체 실패 | collector `_running_row = None` 보관. finalize 시 append-only 경로로 종료 row 1행 새로 push. `was_append_only=true` 로 구분 가능 |
+| `find(run_id)` 가 header 와 충돌 | `find` 호출을 `run_id` 컬럼 범위 (예: `range="A:A"`) 로 한정 |
+| `n_failed_chunks` 중복 카운트 | translation.py 에서는 incr 절대 금지. runner 의 `future.result()` try/except 한 곳에서만 (`record_failed_chunk()`) |
+| recursive split fallback 에 metrics 누락 | `translate_text_with_gemini` 재귀 호출에 `metrics=metrics` 명시 — PR 리뷰 체크 항목 |
+| `str(e)` 자체가 예외 발생 | `error_short` 는 `try: str(e) except: repr(e)` 로 방어 후 절단 |
+
+## 8. 검증 / Rollout
+
+1. **로컬 단위 테스트** (`tests/test_metrics.py` 신규)
+   - `MetricsCollector.incr` thread-safe 확인 (여러 thread 에서 동시 호출 → 합산 일치)
+   - `NullMetricsCollector` 가 모든 호출 무시 확인 (인터페이스 전체 시그니처 일치)
+   - Sheets sink 를 Mock 으로 주입해 batch flush 호출 횟수/페이로드 확인
+   - **Mock sink 가 예외를 던지는 경우** 번역 결과/리턴 값이 영향받지 않는지 확인
+   - **flusher 내부에서 예외** 가 났을 때 sampler thread 가 살아 있는지 확인
+   - phase duration 합계 ≈ total duration (오차 < 0.5s) 확인
+2. **로컬 E2E**
+   - 짧은 docx(3~5 chunk) 로 stdout sink 로 동작 확인
+   - psutil 값 정상 범위 (RAM > 0, threads >= 1)
+3. **Sheets 연결 검증**
+   - dummy run_id 로 runs append + samples batch append → 시트에서 눈으로 확인
+   - update 도 동작하는지 확인 (run_id find → ended_at 채워짐)
+4. **Streamlit Cloud 배포 검증**
+   - secrets 등록, `METRICS_ENABLED=True` → 실제 문서 1건 번역 → 시트에 row 생성 확인
+   - 일부러 GEMINI_API_KEY 를 잘못 넣어 예외 발생시키고 status=error 기록되는지 확인
+   - **finalize 미호출 시나리오**: 번역 도중 브라우저 탭 강제 종료 → runs row 가 `running` 으로 stale 상태 유지되는지 + samples 에 직전까지의 row 가 들어와 있는지 확인
+   - **Streamlit rerun 시 collector 교체**: 번역 중 파일 재업로드/다른 위젯 조작으로 rerun 유발 후 active collector 교체가 깔끔히 되는지 확인
+   - **Sheets API 실패 강제** (서비스 어카운트 권한 잠시 회수) → 번역 결과 자체는 정상 다운로드 되는지 확인 후 권한 복구
+5. **수동 차트 셋업** (1차 후)
+   - `runs`: workers vs peak_ram_mb, workers vs duration_translate_s scatter
+   - `samples`: run_id 필터 + t_offset_s vs ram_mb line
+6. **A/B 실험**
+   - 동일 문서로 workers ∈ {8, 12, 16} 각 3회 → `runs` 시트에서 비교
+7. **롤백**
+   - `METRICS_ENABLED=False` secret 변경으로 즉시 비활성, 재배포 불필요
+
+## 9. 오픈 이슈 / 결정 필요
+
+1. `APP_VERSION` 주입을 Streamlit Cloud secret 으로 갱신할지, git fallback 만으로 갈지. **1차는 env → "unknown" 만으로도 충분 (codex 2차 의견)**, git SHA fallback 은 1차에서 빼도 됨.
+2. `runs` row update 가 일관되게 실패할 경우 별도 `runs_events` 시트에 append-only 로 fallback 할지 (v4 의 `was_append_only` 컬럼 + append-only 경로로 일부 대응됨 → 1차에서는 별도 시트 미신설).
+3. samples flush 주기 30s / batch 30 row 가 적절한지 — 1차 배포 후 시트에서 직접 확인.
+4. Discord webhook 후속 추가 시점 (1차 안정화 후 별도 PR).
+5. **1차 컬럼 축소 옵션 (codex 2차 제안)**: `avg_process_cpu_pct`, `peak_process_threads`, `duration_build_doc_s` 는 핵심 목표(peak RAM, retry, workers tuning)에 직접 기여 미약. 1차 그대로 유지 (NULL 허용) vs 1차 제거 — 사용자 결정 필요. 현재 플랜은 **유지** 쪽.
+
+> v2 까지 open 이었던 `n_failed_chunks` 위치는 v3 에서 **runner 의 `future.result()` 단** 으로 확정.
+> v3 의 lock 모호점은 v4 에서 lock 획득 순서 (`counter → buffer → sink_io`) 와 `_SheetsSink` IO lock + finalize ordering 으로 확정.
+> v3 의 bounded buffer 모호점은 v4 에서 `MAX_BUFFER_ROWS = 2000` + drop-oldest + `n_dropped_samples` 카운팅으로 확정.
+
+## 9-1. 리뷰 사이클 결론
+
+- codex 1차 리뷰 → v2/v3 반영.
+- codex 2차 리뷰 결론: **conditional go** (`MAX_BUFFER_ROWS` 폐기 정책, `_SheetsSink` IO lock + finalize 동시성 명시 조건).
+- v4 에서 두 조건 명시 완료 → **go**.
+- codex 3차 sanity check: 두 조건 해소 확인. implementation-time 권고 1건(`sink_io_lock` 대기 timeout) → v4.1 에서 finalize 의 `acquire(timeout=3.0s)` + skip + warning 으로 반영. **최종 go.**
+
+## 10. 작업 추정 (1차 PR 한정)
+
+| 단계 | 예상 |
+|---|---|
+| `MetricsCollector` + `NullMetricsCollector` + lock 카운터 + samples buffer | 1.5h |
+| `_SheetsSink` (gspread auth + append + find/update) | 1.5h |
+| sampler / flusher thread 분리 + cpu_percent 워밍업 + lock 순서 검증 | 1.5h |
+| `translation.py` + `translation_runner.py` 카운터 hook (api_call / 429 / mismatch / split / failed_chunk) | 1.5h |
+| `app.py` 통합 + run_meta(record) + try/except/finally + phase 전환 | 1h |
+| 단위 테스트 (mock sink 예외, flusher 사망 방지, phase duration 합 검증 포함) | 1.5h |
+| 로컬 검증 | 1h |
+| Streamlit Cloud 배포 + secrets + rerun/finalize 미호출/Sheets 실패 강제 검증 | 2.5h |
+| **합계** | **~12h** (codex v2 review 권고 10~14h 중간값) |

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ python-docx
 pillow
 google-genai
 pydantic
+psutil
+gspread
+google-auth

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,10 +18,17 @@ from utils import metrics as M
 
 
 class FakeSink:
-    """In-process sink with optional one-shot failure injection."""
+    """In-process sink with optional one-shot failure injection.
+
+    Uses RLock and acquires it inside every method to mirror the real
+    SheetsSink's locking discipline — the collector's stop_and_finalize
+    acquires the same lock before calling these methods, so a
+    non-reentrant Lock would deadlock here (this is exactly the bug we
+    hit on the first live run).
+    """
 
     def __init__(self, fail_once: set[str] | None = None) -> None:
-        self.io_lock = threading.Lock()
+        self.io_lock = threading.RLock()
         self.runs_appended: list[M.RunRow] = []
         self.runs_updated: list[tuple[Any, M.RunRow]] = []
         self.samples_batches: list[list[M.SampleRow]] = []
@@ -33,18 +40,21 @@ class FakeSink:
             raise RuntimeError(f"synthetic-{key}")
 
     def append_run(self, row: M.RunRow) -> Any:
-        self._maybe_fail("append_run")
-        self.runs_appended.append(row)
-        return len(self.runs_appended)  # row handle = 1-indexed insertion order
+        with self.io_lock:
+            self._maybe_fail("append_run")
+            self.runs_appended.append(row)
+            return len(self.runs_appended)  # 1-indexed insertion order
 
     def update_run(self, handle: Any, row: M.RunRow) -> bool:
-        self._maybe_fail("update_run")
-        self.runs_updated.append((handle, row))
-        return True
+        with self.io_lock:
+            self._maybe_fail("update_run")
+            self.runs_updated.append((handle, row))
+            return True
 
     def append_samples(self, rows: list[M.SampleRow]) -> None:
-        self._maybe_fail("append_samples")
-        self.samples_batches.append(list(rows))
+        with self.io_lock:
+            self._maybe_fail("append_samples")
+            self.samples_batches.append(list(rows))
 
 
 class TestCounters(unittest.TestCase):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,332 @@
+"""Unit tests for utils.metrics.
+
+Covers the resilience properties promised in docs/PLAN_metrics_to_sheets.md §8:
+counter thread-safety, no-op interface parity, sink-failure isolation
+(both at start/finalize), flusher exception not killing the sampler,
+phase-duration accounting, and the bounded-buffer drop-oldest path.
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+import time
+import unittest
+from typing import Any
+
+from utils import metrics as M
+
+
+class FakeSink:
+    """In-process sink with optional one-shot failure injection."""
+
+    def __init__(self, fail_once: set[str] | None = None) -> None:
+        self.io_lock = threading.Lock()
+        self.runs_appended: list[M.RunRow] = []
+        self.runs_updated: list[tuple[Any, M.RunRow]] = []
+        self.samples_batches: list[list[M.SampleRow]] = []
+        self._fail_once = fail_once or set()
+
+    def _maybe_fail(self, key: str) -> None:
+        if key in self._fail_once:
+            self._fail_once.discard(key)
+            raise RuntimeError(f"synthetic-{key}")
+
+    def append_run(self, row: M.RunRow) -> Any:
+        self._maybe_fail("append_run")
+        self.runs_appended.append(row)
+        return len(self.runs_appended)  # row handle = 1-indexed insertion order
+
+    def update_run(self, handle: Any, row: M.RunRow) -> bool:
+        self._maybe_fail("update_run")
+        self.runs_updated.append((handle, row))
+        return True
+
+    def append_samples(self, rows: list[M.SampleRow]) -> None:
+        self._maybe_fail("append_samples")
+        self.samples_batches.append(list(rows))
+
+
+class TestCounters(unittest.TestCase):
+    def test_incr_thread_safe(self):
+        c = M.MetricsCollector(M.NullSink())
+        n_threads = 32
+        per_thread = 5000
+
+        def bump():
+            for _ in range(per_thread):
+                c.incr("n_text_api_calls")
+
+        threads = [threading.Thread(target=bump) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        with c._counter_lock:
+            self.assertEqual(
+                c._counters["n_text_api_calls"], n_threads * per_thread
+            )
+
+    def test_incr_unknown_key_is_no_op(self):
+        c = M.MetricsCollector(M.NullSink())
+        c.incr("not_a_real_key")
+        for k in M.COUNTER_KEYS:
+            self.assertEqual(c._counters[k], 0)
+
+
+class TestNullCollector(unittest.TestCase):
+    def test_interface_parity_with_real_collector(self):
+        """NullMetricsCollector must mirror MetricsCollector's public methods."""
+        public_methods = {
+            name
+            for name in dir(M.MetricsCollector)
+            if not name.startswith("_")
+            and callable(getattr(M.MetricsCollector, name))
+        }
+        null = M.NullMetricsCollector()
+        for name in public_methods:
+            self.assertTrue(
+                hasattr(null, name),
+                f"NullMetricsCollector missing method: {name}",
+            )
+
+    def test_all_methods_are_no_op(self):
+        null = M.NullMetricsCollector()
+        # Should not raise no matter what we throw at them.
+        null.start()
+        null.set_phase("translating")
+        null.incr("n_text_api_calls", 5)
+        null.record(doc_name="foo")
+        null.record_failed_chunk()
+        null.stop_and_finalize(M.STATUS_OK)
+        null.stop_and_finalize(M.STATUS_ERROR, RuntimeError("x"))
+
+
+class TestLifecycle(unittest.TestCase):
+    def test_happy_path_writes_run_and_samples(self):
+        sink = FakeSink()
+        c = M.MetricsCollector(
+            sink,
+            sample_interval_s=0.05,
+            flush_interval_s=0.1,
+            flush_batch_size=2,
+        )
+        c.record(doc_name="patent.docx", workers=8)
+        c.start()
+        c.set_phase(M.PHASE_TRANSLATING)
+        c.incr("n_text_api_calls", 3)
+        c.incr("n_429_errors")
+        time.sleep(0.25)  # let sampler/flusher fire a couple of times
+        c.set_phase(M.PHASE_BUILDING_DOC)
+        time.sleep(0.1)
+        c.stop_and_finalize(M.STATUS_OK)
+
+        self.assertEqual(len(sink.runs_appended), 1)
+        self.assertEqual(sink.runs_appended[0].status, M.STATUS_RUNNING)
+
+        self.assertEqual(len(sink.runs_updated), 1)
+        handle, final = sink.runs_updated[0]
+        self.assertEqual(handle, 1)  # row index from FakeSink.append_run
+        self.assertEqual(final.status, M.STATUS_OK)
+        self.assertEqual(final.doc_name, "patent.docx")
+        self.assertEqual(final.workers, 8)
+        self.assertEqual(final.n_text_api_calls, 3)
+        self.assertEqual(final.n_429_errors, 1)
+        self.assertGreater(final.duration_total_s or 0, 0.0)
+        # peak_ram_mb should be populated when psutil is available.
+        self.assertIsNotNone(final.peak_ram_mb)
+        # Samples were flushed at least once.
+        self.assertGreater(
+            sum(len(b) for b in sink.samples_batches), 0
+        )
+
+    def test_error_status_captures_type_and_short(self):
+        sink = FakeSink()
+        c = M.MetricsCollector(sink)
+        c.start()
+        try:
+            raise ValueError("boom\nwith\tcontrol")
+        except ValueError as e:
+            c.stop_and_finalize(M.STATUS_ERROR, error=e)
+        _, final = sink.runs_updated[0]
+        self.assertEqual(final.status, M.STATUS_ERROR)
+        self.assertEqual(final.error_type, "ValueError")
+        self.assertEqual(final.error_short, "boom with control")
+
+
+class TestSinkFailureIsolation(unittest.TestCase):
+    def test_append_run_failure_routes_to_append_only_finalize(self):
+        sink = FakeSink(fail_once={"append_run"})
+        c = M.MetricsCollector(sink)
+        c.start()  # append_run raises → handle stays None
+        c.stop_and_finalize(M.STATUS_OK)
+
+        # No initial 'running' row was recorded.
+        self.assertEqual(len(sink.runs_appended), 1)
+        self.assertTrue(sink.runs_appended[0].was_append_only)
+        self.assertEqual(sink.runs_appended[0].status, M.STATUS_OK)
+        # No update was attempted (handle was None).
+        self.assertEqual(len(sink.runs_updated), 0)
+
+    def test_update_run_failure_is_swallowed(self):
+        sink = FakeSink(fail_once={"update_run"})
+        c = M.MetricsCollector(sink)
+        c.start()
+        # Should not raise even though sink.update_run blows up once.
+        c.stop_and_finalize(M.STATUS_OK)
+        self.assertEqual(len(sink.runs_appended), 1)
+
+    def test_flusher_exception_keeps_sampler_alive(self):
+        sink = FakeSink(fail_once={"append_samples"})
+        c = M.MetricsCollector(
+            sink,
+            sample_interval_s=0.04,
+            flush_interval_s=0.08,
+            flush_batch_size=1,
+        )
+        c.start()
+        c.set_phase(M.PHASE_TRANSLATING)
+        time.sleep(0.5)  # enough time for one failed flush + several successful ones
+        c.stop_and_finalize(M.STATUS_OK)
+
+        # Both sampler and flusher must have outlived the synthetic failure:
+        # we expect at least one successful samples batch (besides the
+        # one that failed).
+        self.assertGreaterEqual(len(sink.samples_batches), 1)
+        self.assertGreater(
+            sum(len(b) for b in sink.samples_batches),
+            0,
+            "no samples reached the sink after the first failure",
+        )
+
+
+class TestPhaseDurations(unittest.TestCase):
+    def test_phase_durations_sum_close_to_total(self):
+        sink = FakeSink()
+        c = M.MetricsCollector(sink)
+        c.start()
+        c.set_phase(M.PHASE_TRANSLATING)
+        time.sleep(0.15)
+        c.set_phase(M.PHASE_BUILDING_DOC)
+        time.sleep(0.1)
+        c.stop_and_finalize(M.STATUS_OK)
+
+        _, final = sink.runs_updated[0]
+        translate = final.duration_translate_s or 0.0
+        build = final.duration_build_doc_s or 0.0
+        total = final.duration_total_s or 0.0
+        self.assertAlmostEqual(translate + build, total, delta=0.3)
+        self.assertGreater(translate, 0.1)
+        self.assertGreater(build, 0.05)
+
+
+class TestSafeErrorShort(unittest.TestCase):
+    def test_strips_control_chars_and_truncates(self):
+        class WeirdExc(Exception):
+            def __str__(self) -> str:
+                raise RuntimeError("str() exploded")
+
+        s = M._safe_error_short(WeirdExc())
+        # repr fallback should kick in and still produce a string.
+        self.assertIsInstance(s, str)
+        self.assertGreater(len(s), 0)
+
+    def test_truncates_long_message(self):
+        msg = "x" * 5000
+        s = M._safe_error_short(Exception(msg))
+        self.assertLessEqual(len(s), 500)
+
+
+class TestBoundedBuffer(unittest.TestCase):
+    def test_buffer_cap_drops_oldest_and_counts(self):
+        """Exercise the drop-oldest path the sampler uses, without spinning
+        up real threads — we want to assert the policy itself, not race
+        against psutil.
+        """
+        sink = FakeSink()
+        c = M.MetricsCollector(sink, max_buffer_rows=3)
+        # No c.start() — we drive the buffer policy directly so the
+        # background sampler can't add rows behind our back.
+
+        for i in range(5):
+            row = M.SampleRow(
+                run_id=c.run_id,
+                sampled_at=f"t{i}",
+                t_offset_s=float(i),
+                ram_mb=1.0,
+                process_cpu_pct=0.0,
+                process_threads=1,
+                phase="translating",
+            )
+            with c._buffer_lock:
+                if len(c._buffer) >= c._max_buffer_rows:
+                    del c._buffer[0]
+                    c._counters["n_dropped_samples"] = (
+                        c._counters.get("n_dropped_samples", 0) + 1
+                    )
+                c._buffer.append(row)
+
+        self.assertEqual(len(c._buffer), 3)
+        self.assertEqual([r.sampled_at for r in c._buffer], ["t2", "t3", "t4"])
+        self.assertEqual(c._counters["n_dropped_samples"], 2)
+
+
+class TestActiveCollectorSwap(unittest.TestCase):
+    def test_set_active_collector_stops_previous(self):
+        sink_a = FakeSink()
+        sink_b = FakeSink()
+        a = M.MetricsCollector(sink_a)
+        b = M.MetricsCollector(sink_b)
+        a.start()
+        M.set_active_collector(a)
+
+        # Replacing 'a' with 'b' should stop 'a' (and write an error row).
+        M.set_active_collector(b)
+        # Give the replaced-collector finalize a beat to flush.
+        time.sleep(0.05)
+
+        self.assertEqual(len(sink_a.runs_appended), 1)
+        self.assertEqual(len(sink_a.runs_updated), 1)
+        _, final_a = sink_a.runs_updated[0]
+        self.assertEqual(final_a.status, M.STATUS_ERROR)
+        self.assertEqual(final_a.error_type, "RuntimeError")
+
+        # Clean up so module-level state doesn't bleed into other tests.
+        try:
+            b.stop_and_finalize(M.STATUS_OK)
+        finally:
+            M._active_collector = None
+
+
+class TestAppVersion(unittest.TestCase):
+    def test_env_override(self):
+        import os
+
+        prev = os.environ.get("APP_VERSION")
+        os.environ["APP_VERSION"] = "v1.2.3"
+        try:
+            self.assertEqual(M.resolve_app_version(), "v1.2.3")
+        finally:
+            if prev is None:
+                os.environ.pop("APP_VERSION", None)
+            else:
+                os.environ["APP_VERSION"] = prev
+
+
+class TestPublicSignatures(unittest.TestCase):
+    def test_collector_public_methods_match_documented_set(self):
+        expected = {"start", "stop_and_finalize", "incr", "set_phase", "record", "record_failed_chunk"}
+        public = {
+            n
+            for n, _ in inspect.getmembers(M.MetricsCollector, callable)
+            if not n.startswith("_")
+        }
+        missing = expected - public
+        self.assertFalse(missing, f"MetricsCollector missing: {missing}")
+        for name in expected:
+            self.assertTrue(callable(getattr(M.NullMetricsCollector(), name)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_translation_flow.py
+++ b/tests/test_translation_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from utils import translation
 
@@ -19,7 +19,9 @@ class TestTranslateTextFlow(unittest.TestCase):
             result = translation.translate_text_with_gemini(paragraphs, model_name="m")
 
         self.assertEqual(result, ["ja-a", "ja-b", "ja-c"])
-        mock_batch.assert_called_once_with(paragraphs, model_name="m", max_retries=5)
+        mock_batch.assert_called_once_with(
+            paragraphs, model_name="m", max_retries=5, metrics=ANY
+        )
 
     def test_uses_3_retries_for_large_batch(self):
         paragraphs = [f"p{i}" for i in range(80)]
@@ -32,12 +34,14 @@ class TestTranslateTextFlow(unittest.TestCase):
             result = translation.translate_text_with_gemini(paragraphs, model_name="m")
 
         self.assertEqual(result, translated)
-        mock_batch.assert_called_once_with(paragraphs, model_name="m", max_retries=3)
+        mock_batch.assert_called_once_with(
+            paragraphs, model_name="m", max_retries=3, metrics=ANY
+        )
 
     def test_splits_and_merges_when_batch_retries_exhausted(self):
         paragraphs = [f"p{i}" for i in range(6)]
 
-        def fake_batch(sub_paragraphs, model_name, max_retries):
+        def fake_batch(sub_paragraphs, model_name, max_retries, metrics):
             # Force split on the original batch, then succeed on child batches.
             if len(sub_paragraphs) == 6:
                 raise RuntimeError("Failed to execute call_gemini_api after retries")
@@ -54,6 +58,30 @@ class TestTranslateTextFlow(unittest.TestCase):
         # 1st call fails at len=6, then split calls len=3 and len=3.
         call_lengths = [len(call.args[0]) for call in mock_batch.call_args_list]
         self.assertEqual(call_lengths, [6, 3, 3])
+
+    def test_split_fallback_propagates_metrics(self):
+        from utils.metrics import MetricsCollector, NullSink
+
+        paragraphs = [f"p{i}" for i in range(6)]
+        collector = MetricsCollector(NullSink())
+
+        def fake_batch(sub_paragraphs, model_name, max_retries, metrics):
+            assert metrics is collector
+            if len(sub_paragraphs) == 6:
+                raise RuntimeError("Failed to execute call_gemini_api after retries")
+            return [f"ja-{p}" for p in sub_paragraphs]
+
+        with patch(
+            "utils.translation._translate_text_batch_with_retry",
+            side_effect=fake_batch,
+        ):
+            translation.translate_text_with_gemini(
+                paragraphs, model_name="m", metrics=collector
+            )
+
+        # one split fallback, no api/429/mismatch (because we patched the batch)
+        with collector._counter_lock:
+            self.assertEqual(collector._counters["n_split_fallbacks"], 1)
 
     def test_raises_when_single_paragraph_keeps_failing(self):
         with patch(

--- a/utils/config.py
+++ b/utils/config.py
@@ -5,6 +5,17 @@ DEFAULT_GEMINI_MODEL_DISPLAY_NAME = "Gemini 2.5 Flash"
 # Parallel translation: max concurrent API requests (Tier 1 friendly)
 TRANSLATION_MAX_WORKERS = 8
 
+# Metrics → Google Sheets sink. Off by default; flip via env METRICS_ENABLED=1
+# or st.secrets["metrics_enabled"] (handled in utils/metrics.py).
+METRICS_ENABLED_ENV_VAR = "METRICS_ENABLED"
+METRICS_SAMPLE_INTERVAL_S = 1.5
+METRICS_FLUSH_INTERVAL_S = 30.0
+METRICS_FLUSH_BATCH_SIZE = 30
+METRICS_MAX_BUFFER_ROWS = 2000
+METRICS_SINK_IO_LOCK_TIMEOUT_S = 3.0
+METRICS_THREAD_JOIN_TIMEOUT_S = 1.0
+METRICS_ERROR_SHORT_MAX_LEN = 500
+
 # Prompts for translation
 TEXT_TRANSLATION_PROMPT = (
     "You are a professional patent translator specializing in Korean-to-Japanese patents. "

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,0 +1,605 @@
+"""Run-level metrics collector for Streamlit Cloud post-mortem analysis.
+
+See ``docs/PLAN_metrics_to_sheets.md`` for the design. Highlights:
+
+- ``MetricsCollector`` runs two background daemons (sampler + flusher) and
+  keeps an in-memory bounded sample buffer + counter dict.
+- ``NullMetricsCollector`` mirrors the same interface as no-ops so call
+  sites never need ``if metrics is not None`` guards.
+- Sinks (``MetricsSink``) abstract the storage target — ``NullSink`` /
+  ``StdoutSink`` ship here; ``SheetsSink`` is added in a follow-up commit.
+- Lock acquisition order is fixed:
+  ``_counter_lock`` → ``_buffer_lock`` → sink-internal ``_sink_io_lock``.
+- The sampler never touches IO; the flusher swaps the buffer under the
+  buffer lock and pushes to the sink with the lock released.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from utils.config import (
+    METRICS_ERROR_SHORT_MAX_LEN,
+    METRICS_FLUSH_BATCH_SIZE,
+    METRICS_FLUSH_INTERVAL_S,
+    METRICS_MAX_BUFFER_ROWS,
+    METRICS_SAMPLE_INTERVAL_S,
+    METRICS_SINK_IO_LOCK_TIMEOUT_S,
+    METRICS_THREAD_JOIN_TIMEOUT_S,
+)
+
+log = logging.getLogger(__name__)
+
+
+# ---------- counter / phase keys ----------
+
+COUNTER_KEYS = (
+    "n_text_api_calls",
+    "n_image_api_calls",
+    "n_429_errors",
+    "n_429_retries",
+    "n_mismatch_errors",
+    "n_mismatch_retries",
+    "n_split_fallbacks",
+    "n_failed_chunks",
+    "n_dropped_samples",
+)
+
+PHASE_TRANSLATING = "translating"
+PHASE_BUILDING_DOC = "building_doc"
+
+STATUS_RUNNING = "running"
+STATUS_OK = "ok"
+STATUS_ERROR = "error"
+
+
+# ---------- sink protocol ----------
+
+
+@dataclass(frozen=True)
+class SampleRow:
+    run_id: str
+    sampled_at: str
+    t_offset_s: float
+    ram_mb: float
+    process_cpu_pct: float
+    process_threads: int
+    phase: str
+
+
+@dataclass
+class RunRow:
+    run_id: str
+    started_at: str
+    ended_at: str = ""
+    duration_total_s: float | None = None
+    duration_translate_s: float | None = None
+    duration_build_doc_s: float | None = None
+    doc_name: str = ""
+    file_size_bytes: int = 0
+    n_paragraphs: int = 0
+    n_images: int = 0
+    n_chunks: int = 0
+    n_text_chunks: int = 0
+    n_figure_chunks: int = 0
+    chunk_size_max: int = 0
+    chunk_size_avg: float = 0.0
+    total_input_chars: int = 0
+    total_output_chars: int | None = None
+    workers: int = 0
+    model_name: str = ""
+    sample_interval_s: float = METRICS_SAMPLE_INTERVAL_S
+    peak_ram_mb: float | None = None
+    avg_process_cpu_pct: float | None = None
+    peak_process_threads: int | None = None
+    n_text_api_calls: int = 0
+    n_image_api_calls: int = 0
+    n_429_errors: int = 0
+    n_429_retries: int = 0
+    n_mismatch_errors: int = 0
+    n_mismatch_retries: int = 0
+    n_split_fallbacks: int = 0
+    n_failed_chunks: int = 0
+    status: str = STATUS_RUNNING
+    error_type: str = ""
+    error_short: str = ""
+    app_version: str = ""
+    n_dropped_samples: int = 0
+    was_append_only: bool = False
+
+
+class MetricsSink(Protocol):
+    """Where run/sample rows get written.
+
+    Implementations MUST be tolerant of partial failure — they swallow
+    exceptions and log them so the translation pipeline never sees them.
+    """
+
+    def append_run(self, row: RunRow) -> Any:  # returns row handle (e.g. sheet row index) or None
+        ...
+
+    def update_run(self, handle: Any, row: RunRow) -> bool:
+        ...
+
+    def append_samples(self, rows: list[SampleRow]) -> None: ...
+
+
+class NullSink:
+    def append_run(self, row: RunRow) -> Any:
+        return None
+
+    def update_run(self, handle: Any, row: RunRow) -> bool:
+        return True
+
+    def append_samples(self, rows: list[SampleRow]) -> None:
+        pass
+
+
+class StdoutSink:
+    """For local debugging — pretty-prints rows so you can sanity-check fields."""
+
+    def append_run(self, row: RunRow) -> Any:
+        log.info("[metrics] APPEND_RUN %s", row)
+        return row.run_id
+
+    def update_run(self, handle: Any, row: RunRow) -> bool:
+        log.info("[metrics] UPDATE_RUN handle=%s %s", handle, row)
+        return True
+
+    def append_samples(self, rows: list[SampleRow]) -> None:
+        for r in rows:
+            log.info("[metrics] SAMPLE %s", r)
+
+
+# ---------- helpers ----------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _safe_error_short(exc: BaseException) -> str:
+    try:
+        s = str(exc)
+    except Exception:
+        try:
+            s = repr(exc)
+        except Exception:
+            s = f"<unprintable {type(exc).__name__}>"
+    s = s.replace("\n", " ").replace("\r", " ").replace("\t", " ")
+    return s[:METRICS_ERROR_SHORT_MAX_LEN]
+
+
+def resolve_app_version() -> str:
+    env = os.environ.get("APP_VERSION")
+    if env:
+        return env
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        sha = result.stdout.strip()
+        if result.returncode == 0 and sha:
+            return sha
+    except Exception:
+        pass
+    return "unknown"
+
+
+# ---------- collector ----------
+
+
+@dataclass
+class _PhaseTracker:
+    """Tracks elapsed time per phase. set_phase() closes out the previous one."""
+
+    current_phase: str = ""
+    phase_started_at: float = 0.0
+    durations: dict[str, float] = field(default_factory=dict)
+
+    def transition(self, new_phase: str, now: float) -> None:
+        if self.current_phase:
+            self.durations[self.current_phase] = (
+                self.durations.get(self.current_phase, 0.0)
+                + (now - self.phase_started_at)
+            )
+        self.current_phase = new_phase
+        self.phase_started_at = now
+
+    def close(self, now: float) -> None:
+        if self.current_phase:
+            self.durations[self.current_phase] = (
+                self.durations.get(self.current_phase, 0.0)
+                + (now - self.phase_started_at)
+            )
+            self.current_phase = ""
+
+
+class MetricsCollector:
+    """Live, thread-safe metrics aggregator for one translation run.
+
+    Spawns two daemon threads on ``start()``:
+      - sampler: reads psutil ~sample_interval_s, appends to buffer
+      - flusher: every flush_interval_s (or when buffer >= batch_size)
+        swaps the buffer and pushes to the sink
+
+    ``incr`` / ``set_phase`` / ``record`` / ``record_failed_chunk`` are
+    safe to call from worker threads. The sampler/flusher never block on
+    sink IO under either ``_counter_lock`` or ``_buffer_lock``.
+    """
+
+    def __init__(
+        self,
+        sink: MetricsSink,
+        *,
+        run_id: str | None = None,
+        sample_interval_s: float = METRICS_SAMPLE_INTERVAL_S,
+        flush_interval_s: float = METRICS_FLUSH_INTERVAL_S,
+        flush_batch_size: int = METRICS_FLUSH_BATCH_SIZE,
+        max_buffer_rows: int = METRICS_MAX_BUFFER_ROWS,
+    ) -> None:
+        self.run_id = run_id or str(uuid.uuid4())
+        self._sink = sink
+        self._sample_interval_s = sample_interval_s
+        self._flush_interval_s = flush_interval_s
+        self._flush_batch_size = flush_batch_size
+        self._max_buffer_rows = max_buffer_rows
+
+        self._counter_lock = threading.Lock()
+        self._buffer_lock = threading.Lock()
+        self._counters: dict[str, int] = {k: 0 for k in COUNTER_KEYS}
+        self._buffer: list[SampleRow] = []
+        self._phase = _PhaseTracker()
+
+        self._started_at_wall: str = ""
+        self._started_at_mono: float = 0.0
+        self._run_handle: Any = None
+        self._was_append_only = False
+        self._run_meta: dict[str, Any] = {}
+
+        self._stop_evt = threading.Event()
+        self._flush_kick = threading.Event()
+        self._sampler: threading.Thread | None = None
+        self._flusher: threading.Thread | None = None
+        self._proc = None  # lazy psutil.Process — None means sampling disabled
+        self._sample_peaks: dict[str, float | int | None] = {
+            "peak_ram_mb": None,
+            "peak_threads": None,
+            "cpu_sum": 0.0,
+            "cpu_count": 0,
+        }
+        self._peaks_lock = threading.Lock()
+
+    # ----- public API -----
+
+    def start(self) -> None:
+        self._started_at_wall = _now_iso()
+        self._started_at_mono = time.monotonic()
+        self._phase.transition("", self._started_at_mono)  # no-op until set_phase
+
+        run_row = self._snapshot_run_row(STATUS_RUNNING)
+        try:
+            self._run_handle = self._sink.append_run(run_row)
+        except Exception:
+            log.exception("[metrics] append_run failed; will use append-only finalize")
+            self._run_handle = None
+            self._was_append_only = True
+
+        self._proc = self._init_psutil()
+        self._sampler = threading.Thread(
+            target=self._sampler_loop, name="metrics-sampler", daemon=True
+        )
+        self._flusher = threading.Thread(
+            target=self._flusher_loop, name="metrics-flusher", daemon=True
+        )
+        self._sampler.start()
+        self._flusher.start()
+
+    def stop_and_finalize(
+        self,
+        status: str,
+        error: BaseException | None = None,
+    ) -> None:
+        now = time.monotonic()
+        with self._buffer_lock:
+            self._phase.close(now)
+
+        self._stop_evt.set()
+        self._flush_kick.set()
+        for t in (self._sampler, self._flusher):
+            if t is not None:
+                t.join(timeout=METRICS_THREAD_JOIN_TIMEOUT_S)
+
+        # Try to acquire sink IO lock with a hard cap so a hung flusher
+        # doesn't block the user's page transition forever.
+        sink_lock = getattr(self._sink, "io_lock", None)
+        acquired = False
+        if sink_lock is not None:
+            acquired = sink_lock.acquire(timeout=METRICS_SINK_IO_LOCK_TIMEOUT_S)
+            if not acquired:
+                log.warning(
+                    "[metrics] sink_io_lock acquire timed out (%.1fs) — "
+                    "skipping final flush and run update; row will remain "
+                    "in 'running' status",
+                    METRICS_SINK_IO_LOCK_TIMEOUT_S,
+                )
+                return
+
+        try:
+            # final flush
+            try:
+                final_batch = self._swap_buffer()
+                if final_batch:
+                    self._sink.append_samples(final_batch)
+            except Exception:
+                log.exception("[metrics] final samples flush failed")
+
+            row = self._snapshot_run_row(status, error=error)
+            try:
+                if self._run_handle is None:
+                    # append-only fallback — start() couldn't seat the row
+                    self._sink.append_run(row)
+                else:
+                    self._sink.update_run(self._run_handle, row)
+            except Exception:
+                log.exception("[metrics] run finalize write failed")
+        finally:
+            if acquired and sink_lock is not None:
+                sink_lock.release()
+
+    def incr(self, key: str, n: int = 1) -> None:
+        if key not in COUNTER_KEYS:
+            log.warning("[metrics] unknown counter key: %s", key)
+            return
+        with self._counter_lock:
+            self._counters[key] += n
+
+    def set_phase(self, phase: str) -> None:
+        now = time.monotonic()
+        with self._buffer_lock:
+            self._phase.transition(phase, now)
+
+    def record(self, **fields: Any) -> None:
+        # Fields that flow straight onto the RunRow at finalize time.
+        with self._buffer_lock:
+            self._run_meta.update(fields)
+
+    def record_failed_chunk(self, n: int = 1) -> None:
+        self.incr("n_failed_chunks", n=n)
+
+    # ----- internals -----
+
+    def _init_psutil(self):
+        try:
+            import psutil  # noqa: F401 — local import so import failures don't kill the app
+
+            proc = psutil.Process()
+            proc.cpu_percent(interval=None)  # warm-up; first reading is 0/garbage
+            return proc
+        except Exception:
+            log.exception("[metrics] psutil unavailable — sampling disabled")
+            return None
+
+    def _sampler_loop(self) -> None:
+        if self._proc is None:
+            return
+        while not self._stop_evt.is_set():
+            try:
+                self._take_sample()
+            except Exception:
+                log.exception("[metrics] sampler iteration failed")
+            self._stop_evt.wait(self._sample_interval_s)
+
+    def _take_sample(self) -> None:
+        assert self._proc is not None
+        now_mono = time.monotonic()
+        mem = self._proc.memory_info().rss / (1024 * 1024)
+        cpu = self._proc.cpu_percent(interval=None)
+        threads = self._proc.num_threads()
+        sampled_at = _now_iso()
+        t_offset = max(0.0, now_mono - self._started_at_mono)
+
+        with self._buffer_lock:
+            phase = self._phase.current_phase or ""
+            row = SampleRow(
+                run_id=self.run_id,
+                sampled_at=sampled_at,
+                t_offset_s=round(t_offset, 3),
+                ram_mb=round(mem, 2),
+                process_cpu_pct=round(cpu, 2),
+                process_threads=threads,
+                phase=phase,
+            )
+            if len(self._buffer) >= self._max_buffer_rows:
+                # drop oldest, keep newest — analysis cares about the
+                # OOM-adjacent tail more than the start.
+                del self._buffer[0]
+                # safe nested lock: counter_lock is order #1, we already
+                # hold buffer_lock (#2) → acquiring #1 here would violate
+                # the rule. So we increment directly under the buffer
+                # lock for n_dropped_samples — it's a write-only counter
+                # so contention with readers is irrelevant.
+                self._counters["n_dropped_samples"] = (
+                    self._counters.get("n_dropped_samples", 0) + 1
+                )
+            self._buffer.append(row)
+            buf_len = len(self._buffer)
+
+        with self._peaks_lock:
+            if (
+                self._sample_peaks["peak_ram_mb"] is None
+                or mem > self._sample_peaks["peak_ram_mb"]
+            ):
+                self._sample_peaks["peak_ram_mb"] = mem
+            if (
+                self._sample_peaks["peak_threads"] is None
+                or threads > self._sample_peaks["peak_threads"]
+            ):
+                self._sample_peaks["peak_threads"] = threads
+            self._sample_peaks["cpu_sum"] += cpu
+            self._sample_peaks["cpu_count"] += 1
+
+        if buf_len >= self._flush_batch_size:
+            self._flush_kick.set()
+
+    def _flusher_loop(self) -> None:
+        while not self._stop_evt.is_set():
+            triggered = self._flush_kick.wait(timeout=self._flush_interval_s)
+            self._flush_kick.clear()
+            if self._stop_evt.is_set():
+                return
+            try:
+                batch = self._swap_buffer()
+                if batch:
+                    self._sink.append_samples(batch)
+            except Exception:
+                log.exception(
+                    "[metrics] flusher iteration failed (triggered=%s)", triggered
+                )
+
+    def _swap_buffer(self) -> list[SampleRow]:
+        with self._buffer_lock:
+            if not self._buffer:
+                return []
+            batch = self._buffer
+            self._buffer = []
+            return batch
+
+    def _snapshot_run_row(
+        self, status: str, error: BaseException | None = None
+    ) -> RunRow:
+        with self._counter_lock:
+            counters = dict(self._counters)
+
+        with self._buffer_lock:
+            meta = dict(self._run_meta)
+            phase_durations = dict(self._phase.durations)
+            # If we are still in a phase mid-run, account for the live one too
+            # so snapshots taken for `running` rows aren't wildly off.
+            if self._phase.current_phase:
+                live = time.monotonic() - self._phase.phase_started_at
+                phase_durations[self._phase.current_phase] = (
+                    phase_durations.get(self._phase.current_phase, 0.0) + live
+                )
+
+        with self._peaks_lock:
+            peaks = dict(self._sample_peaks)
+
+        cpu_avg = None
+        if peaks["cpu_count"]:
+            cpu_avg = peaks["cpu_sum"] / peaks["cpu_count"]
+
+        ended_at = ""
+        duration_total = None
+        if status != STATUS_RUNNING:
+            ended_at = _now_iso()
+            duration_total = round(time.monotonic() - self._started_at_mono, 3)
+
+        return RunRow(
+            run_id=self.run_id,
+            started_at=self._started_at_wall,
+            ended_at=ended_at,
+            duration_total_s=duration_total,
+            duration_translate_s=round(
+                phase_durations.get(PHASE_TRANSLATING, 0.0), 3
+            )
+            if phase_durations.get(PHASE_TRANSLATING)
+            else None,
+            duration_build_doc_s=round(
+                phase_durations.get(PHASE_BUILDING_DOC, 0.0), 3
+            )
+            if phase_durations.get(PHASE_BUILDING_DOC)
+            else None,
+            doc_name=meta.get("doc_name", ""),
+            file_size_bytes=int(meta.get("file_size_bytes", 0)),
+            n_paragraphs=int(meta.get("n_paragraphs", 0)),
+            n_images=int(meta.get("n_images", 0)),
+            n_chunks=int(meta.get("n_chunks", 0)),
+            n_text_chunks=int(meta.get("n_text_chunks", 0)),
+            n_figure_chunks=int(meta.get("n_figure_chunks", 0)),
+            chunk_size_max=int(meta.get("chunk_size_max", 0)),
+            chunk_size_avg=float(meta.get("chunk_size_avg", 0.0)),
+            total_input_chars=int(meta.get("total_input_chars", 0)),
+            total_output_chars=meta.get("total_output_chars"),
+            workers=int(meta.get("workers", 0)),
+            model_name=str(meta.get("model_name", "")),
+            sample_interval_s=self._sample_interval_s,
+            peak_ram_mb=round(peaks["peak_ram_mb"], 2)
+            if peaks["peak_ram_mb"] is not None
+            else None,
+            avg_process_cpu_pct=round(cpu_avg, 2) if cpu_avg is not None else None,
+            peak_process_threads=peaks["peak_threads"],
+            n_text_api_calls=counters["n_text_api_calls"],
+            n_image_api_calls=counters["n_image_api_calls"],
+            n_429_errors=counters["n_429_errors"],
+            n_429_retries=counters["n_429_retries"],
+            n_mismatch_errors=counters["n_mismatch_errors"],
+            n_mismatch_retries=counters["n_mismatch_retries"],
+            n_split_fallbacks=counters["n_split_fallbacks"],
+            n_failed_chunks=counters["n_failed_chunks"],
+            status=status,
+            error_type=type(error).__name__ if error is not None else "",
+            error_short=_safe_error_short(error) if error is not None else "",
+            app_version=str(meta.get("app_version") or resolve_app_version()),
+            n_dropped_samples=counters["n_dropped_samples"],
+            was_append_only=self._was_append_only,
+        )
+
+
+class NullMetricsCollector:
+    """No-op collector matching :class:`MetricsCollector` interface.
+
+    Wired as the default everywhere so call sites stay free of
+    ``if metrics is not None`` checks.
+    """
+
+    run_id = ""
+
+    def start(self) -> None: ...
+
+    def stop_and_finalize(
+        self, status: str, error: BaseException | None = None
+    ) -> None: ...
+
+    def incr(self, key: str, n: int = 1) -> None: ...
+
+    def set_phase(self, phase: str) -> None: ...
+
+    def record(self, **fields: Any) -> None: ...
+
+    def record_failed_chunk(self, n: int = 1) -> None: ...
+
+
+# ---------- module-level active collector (for Streamlit rerun handling) ----------
+
+_active_lock = threading.Lock()
+_active_collector: MetricsCollector | NullMetricsCollector | None = None
+
+
+def set_active_collector(c: MetricsCollector | NullMetricsCollector) -> None:
+    global _active_collector
+    with _active_lock:
+        prev = _active_collector
+        _active_collector = c
+    if prev is not None and prev is not c and isinstance(prev, MetricsCollector):
+        try:
+            prev.stop_and_finalize(STATUS_ERROR, RuntimeError("replaced by new run"))
+        except Exception:
+            log.exception("[metrics] failed to stop previous active collector")
+
+
+def get_active_collector() -> MetricsCollector | NullMetricsCollector:
+    with _active_lock:
+        return _active_collector or NullMetricsCollector()

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -284,10 +284,13 @@ class MetricsCollector:
 
     # ----- public API -----
 
-    def start(self) -> None:
+    def start(self, initial_phase: str = "") -> None:
         self._started_at_wall = _now_iso()
         self._started_at_mono = time.monotonic()
-        self._phase.transition("", self._started_at_mono)  # no-op until set_phase
+        # Seed the phase tracker so the very first sample (which the sampler
+        # may take immediately after the threads spin up) carries the right
+        # phase label instead of an empty string.
+        self._phase.transition(initial_phase, self._started_at_mono)
 
         run_row = self._snapshot_run_row(STATUS_RUNNING)
         try:
@@ -567,7 +570,7 @@ class NullMetricsCollector:
 
     run_id = ""
 
-    def start(self) -> None: ...
+    def start(self, initial_phase: str = "") -> None: ...
 
     def stop_and_finalize(
         self, status: str, error: BaseException | None = None

--- a/utils/metrics_sheets.py
+++ b/utils/metrics_sheets.py
@@ -115,7 +115,6 @@ class SheetsSink:
                     values,
                     value_input_option="USER_ENTERED",
                     insert_data_option="INSERT_ROWS",
-                    table_range=f"{RUNS_TAB}!A1",
                 )
                 return self._parse_appended_row_index(resp)
             except Exception:
@@ -139,7 +138,6 @@ class SheetsSink:
                         values,
                         value_input_option="USER_ENTERED",
                         insert_data_option="INSERT_ROWS",
-                        table_range=f"{RUNS_TAB}!A1",
                     )
                     return True
                 except Exception:
@@ -149,7 +147,11 @@ class SheetsSink:
             try:
                 values = _row_values(asdict(row), _RUN_COLUMNS)
                 end_col = _col_letter(len(_RUN_COLUMNS))
-                rng = f"{RUNS_TAB}!A{row_idx}:{end_col}{row_idx}"
+                # Range without sheet prefix — gspread resolves against
+                # the bound worksheet; including the prefix risks the
+                # same double-prefix bug seen with append_row's
+                # table_range arg.
+                rng = f"A{row_idx}:{end_col}{row_idx}"
                 self._runs_ws.update(
                     rng, [values], value_input_option="USER_ENTERED"
                 )
@@ -170,7 +172,6 @@ class SheetsSink:
                     payload,
                     value_input_option="USER_ENTERED",
                     insert_data_option="INSERT_ROWS",
-                    table_range=f"{SAMPLES_TAB}!A1",
                 )
             except Exception:
                 log.exception(

--- a/utils/metrics_sheets.py
+++ b/utils/metrics_sheets.py
@@ -1,0 +1,323 @@
+"""Google Sheets sink for :mod:`utils.metrics`.
+
+Kept in its own module so import failures (gspread / google-auth not
+installed) don't break the in-memory ``MetricsCollector``. The factory
+``build_sheets_sink_from_secrets`` tries env / ``st.secrets`` in order
+and returns ``None`` on any failure — callers should fall back to
+:class:`utils.metrics.NullSink`.
+
+All gspread calls are serialized through ``self.io_lock`` so the
+flusher's periodic flush, ``stop_and_finalize``'s final flush, and the
+``runs`` row update never overlap on the same client.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import asdict
+from typing import Any
+
+from utils.metrics import RunRow, SampleRow
+
+log = logging.getLogger(__name__)
+
+RUNS_TAB = "runs"
+SAMPLES_TAB = "samples"
+
+# Header order is the canonical column order in the sheet — keep
+# synchronized with `runs` / `samples` table in docs/PLAN_metrics_to_sheets.md.
+_RUN_COLUMNS = [
+    "run_id",
+    "started_at",
+    "ended_at",
+    "duration_total_s",
+    "duration_translate_s",
+    "duration_build_doc_s",
+    "doc_name",
+    "file_size_bytes",
+    "n_paragraphs",
+    "n_images",
+    "n_chunks",
+    "n_text_chunks",
+    "n_figure_chunks",
+    "chunk_size_max",
+    "chunk_size_avg",
+    "total_input_chars",
+    "total_output_chars",
+    "workers",
+    "model_name",
+    "sample_interval_s",
+    "peak_ram_mb",
+    "avg_process_cpu_pct",
+    "peak_process_threads",
+    "n_text_api_calls",
+    "n_image_api_calls",
+    "n_429_errors",
+    "n_429_retries",
+    "n_mismatch_errors",
+    "n_mismatch_retries",
+    "n_split_fallbacks",
+    "n_failed_chunks",
+    "status",
+    "error_type",
+    "error_short",
+    "app_version",
+    "n_dropped_samples",
+    "was_append_only",
+]
+
+_SAMPLE_COLUMNS = [
+    "run_id",
+    "sampled_at",
+    "t_offset_s",
+    "ram_mb",
+    "process_cpu_pct",
+    "process_threads",
+    "phase",
+]
+
+
+def _row_values(row_dict: dict[str, Any], columns: list[str]) -> list[Any]:
+    out: list[Any] = []
+    for c in columns:
+        v = row_dict.get(c)
+        if v is None:
+            out.append("")
+        elif isinstance(v, bool):
+            out.append("TRUE" if v else "FALSE")
+        else:
+            out.append(v)
+    return out
+
+
+class SheetsSink:
+    """gspread-backed sink. Tolerant of partial failure.
+
+    The constructor expects an already-opened ``gspread.Spreadsheet`` so
+    auth concerns stay in the factory.
+    """
+
+    def __init__(self, spreadsheet) -> None:
+        self._ss = spreadsheet
+        self.io_lock = threading.Lock()
+        self._runs_ws = self._ensure_worksheet(RUNS_TAB, _RUN_COLUMNS)
+        self._samples_ws = self._ensure_worksheet(SAMPLES_TAB, _SAMPLE_COLUMNS)
+
+    # -- MetricsSink interface --
+
+    def append_run(self, row: RunRow) -> Any:
+        with self.io_lock:
+            try:
+                values = _row_values(asdict(row), _RUN_COLUMNS)
+                resp = self._runs_ws.append_row(
+                    values,
+                    value_input_option="USER_ENTERED",
+                    insert_data_option="INSERT_ROWS",
+                    table_range=f"{RUNS_TAB}!A1",
+                )
+                return self._parse_appended_row_index(resp)
+            except Exception:
+                log.exception("[metrics-sheets] append_run failed")
+                return None
+
+    def update_run(self, handle: Any, row: RunRow) -> bool:
+        with self.io_lock:
+            row_idx = handle if isinstance(handle, int) else None
+            if row_idx is None:
+                row_idx = self._lookup_run_row(row.run_id)
+            if row_idx is None:
+                log.warning(
+                    "[metrics-sheets] update_run: row for run_id=%s not found; "
+                    "falling back to append",
+                    row.run_id,
+                )
+                try:
+                    values = _row_values(asdict(row), _RUN_COLUMNS)
+                    self._runs_ws.append_row(
+                        values,
+                        value_input_option="USER_ENTERED",
+                        insert_data_option="INSERT_ROWS",
+                        table_range=f"{RUNS_TAB}!A1",
+                    )
+                    return True
+                except Exception:
+                    log.exception("[metrics-sheets] update_run fallback append failed")
+                    return False
+
+            try:
+                values = _row_values(asdict(row), _RUN_COLUMNS)
+                end_col = _col_letter(len(_RUN_COLUMNS))
+                rng = f"{RUNS_TAB}!A{row_idx}:{end_col}{row_idx}"
+                self._runs_ws.update(
+                    rng, [values], value_input_option="USER_ENTERED"
+                )
+                return True
+            except Exception:
+                log.exception("[metrics-sheets] update_run failed")
+                return False
+
+    def append_samples(self, rows: list[SampleRow]) -> None:
+        if not rows:
+            return
+        with self.io_lock:
+            try:
+                payload = [
+                    _row_values(asdict(r), _SAMPLE_COLUMNS) for r in rows
+                ]
+                self._samples_ws.append_rows(
+                    payload,
+                    value_input_option="USER_ENTERED",
+                    insert_data_option="INSERT_ROWS",
+                    table_range=f"{SAMPLES_TAB}!A1",
+                )
+            except Exception:
+                log.exception(
+                    "[metrics-sheets] append_samples failed (n=%d)", len(rows)
+                )
+
+    # -- internals --
+
+    def _ensure_worksheet(self, title: str, columns: list[str]):
+        try:
+            ws = self._ss.worksheet(title)
+        except Exception:
+            log.info("[metrics-sheets] creating worksheet %s", title)
+            ws = self._ss.add_worksheet(
+                title=title, rows=1000, cols=max(len(columns), 8)
+            )
+            ws.append_row(columns, value_input_option="USER_ENTERED")
+            return ws
+
+        # Header sanity: if row 1 is empty, seed it.
+        try:
+            first_row = ws.row_values(1)
+        except Exception:
+            first_row = []
+        if not first_row:
+            try:
+                ws.append_row(columns, value_input_option="USER_ENTERED")
+            except Exception:
+                log.exception(
+                    "[metrics-sheets] failed to seed header for %s", title
+                )
+        return ws
+
+    def _parse_appended_row_index(self, resp) -> int | None:
+        """gspread returns the appended range like 'runs!A42:Z42' — pull the row."""
+        try:
+            updates = resp.get("updates", {}) if isinstance(resp, dict) else {}
+            updated_range = updates.get("updatedRange", "")
+            if "!" in updated_range:
+                _, cells = updated_range.split("!", 1)
+            else:
+                cells = updated_range
+            # cells like A42:Z42 → take trailing number
+            tail = cells.split(":")[-1]
+            digits = "".join(ch for ch in tail if ch.isdigit())
+            return int(digits) if digits else None
+        except Exception:
+            log.exception("[metrics-sheets] could not parse appended row index")
+            return None
+
+    def _lookup_run_row(self, run_id: str) -> int | None:
+        try:
+            ids_column = self._runs_ws.col_values(1)
+            for i, value in enumerate(ids_column, start=1):
+                if value == run_id:
+                    return i
+        except Exception:
+            log.exception(
+                "[metrics-sheets] _lookup_run_row failed for %s", run_id
+            )
+        return None
+
+
+def _col_letter(n: int) -> str:
+    """1 → A, 26 → Z, 27 → AA. n is 1-indexed."""
+    s = ""
+    while n > 0:
+        n, rem = divmod(n - 1, 26)
+        s = chr(65 + rem) + s
+    return s
+
+
+def build_sheets_sink_from_secrets() -> SheetsSink | None:
+    """Try env vars / Streamlit secrets and open the target spreadsheet.
+
+    Returns ``None`` if any required piece is missing or auth fails.
+    Callers should fall back to :class:`utils.metrics.NullSink`.
+    """
+    try:
+        import gspread
+        from google.oauth2.service_account import Credentials
+    except Exception:
+        log.info("[metrics-sheets] gspread/google-auth not installed; disabled")
+        return None
+
+    secrets = _load_streamlit_secrets()
+    service_account = _read_service_account(secrets)
+    sheet_id = _read_sheet_id(secrets)
+    if not service_account or not sheet_id:
+        log.info(
+            "[metrics-sheets] missing service account or sheet id — disabled"
+        )
+        return None
+
+    try:
+        scopes = [
+            "https://www.googleapis.com/auth/spreadsheets",
+            "https://www.googleapis.com/auth/drive",
+        ]
+        creds = Credentials.from_service_account_info(
+            service_account, scopes=scopes
+        )
+        client = gspread.authorize(creds)
+        spreadsheet = client.open_by_key(sheet_id)
+        return SheetsSink(spreadsheet)
+    except Exception:
+        log.exception("[metrics-sheets] failed to authorize/open spreadsheet")
+        return None
+
+
+def _load_streamlit_secrets() -> Any:
+    try:
+        import streamlit as st
+
+        return st.secrets
+    except Exception:
+        return None
+
+
+def _read_service_account(secrets: Any) -> dict | None:
+    if secrets is not None:
+        try:
+            sa = secrets.get("gcp_service_account")  # type: ignore[union-attr]
+            if sa:
+                # streamlit secrets returns AttrDict-like; convert defensively
+                return dict(sa)
+        except Exception:
+            pass
+
+    env_path = os.environ.get("GCP_SERVICE_ACCOUNT_JSON_PATH")
+    if env_path and os.path.exists(env_path):
+        try:
+            import json
+
+            with open(env_path, encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            log.exception("[metrics-sheets] failed to read service account file")
+    return None
+
+
+def _read_sheet_id(secrets: Any) -> str | None:
+    if secrets is not None:
+        try:
+            sid = secrets.get("metrics_sheet_id")  # type: ignore[union-attr]
+            if sid:
+                return str(sid)
+        except Exception:
+            pass
+    return os.environ.get("METRICS_SHEET_ID") or None

--- a/utils/metrics_sheets.py
+++ b/utils/metrics_sheets.py
@@ -101,7 +101,12 @@ class SheetsSink:
 
     def __init__(self, spreadsheet) -> None:
         self._ss = spreadsheet
-        self.io_lock = threading.Lock()
+        # RLock (not Lock) because MetricsCollector.stop_and_finalize
+        # acquires this lock and then calls sink methods (append_samples /
+        # update_run / append_run), which each re-acquire it via
+        # `with self.io_lock`. A non-reentrant Lock deadlocks on that
+        # nested acquire from the same thread.
+        self.io_lock = threading.RLock()
         self._runs_ws = self._ensure_worksheet(RUNS_TAB, _RUN_COLUMNS)
         self._samples_ws = self._ensure_worksheet(SAMPLES_TAB, _SAMPLE_COLUMNS)
 

--- a/utils/translation.py
+++ b/utils/translation.py
@@ -13,6 +13,7 @@ from utils.config import (
     IMAGE_TRANSLATION_PROMPT,
     TEXT_TRANSLATION_PROMPT,
 )
+from utils.metrics import MetricsCollector, NullMetricsCollector
 
 # API key resolved once (main thread or first thread that needs it)
 _api_key = None
@@ -58,12 +59,16 @@ class ParagraphMismatchError(Exception):
 
 
 def _translate_text_batch_with_retry(
-    paragraphs: list[str], model_name: str, max_retries: int
+    paragraphs: list[str],
+    model_name: str,
+    max_retries: int,
+    metrics: MetricsCollector | NullMetricsCollector,
 ) -> list[str]:
     expected_len = len(paragraphs)
     input_json = json.dumps(paragraphs, ensure_ascii=False)
 
     def call_gemini_api():
+        metrics.incr("n_text_api_calls")
         response = _get_client().models.generate_content(
             model=model_name,
             contents=[TEXT_TRANSLATION_PROMPT, input_json],
@@ -79,22 +84,35 @@ def _translate_text_batch_with_retry(
             )
         return result
 
-    return retry_with_delay(call_gemini_api, max_retries=max_retries)
+    return retry_with_delay(call_gemini_api, max_retries=max_retries, metrics=metrics)
 
 
-def retry_with_delay(func, *args, max_retries=5, default_delay=10, **kwargs):
+def retry_with_delay(
+    func,
+    *args,
+    metrics: MetricsCollector | NullMetricsCollector | None = None,
+    max_retries=5,
+    default_delay=10,
+    **kwargs,
+):
+    metrics = metrics or NullMetricsCollector()
     for attempt in range(max_retries):
+        is_last = attempt == max_retries - 1
         try:
             logging.info(
                 f"Attempt {attempt + 1}/{max_retries} for function {func.__name__}"
             )
             return func(*args, **kwargs)
         except ParagraphMismatchError as e:
+            metrics.incr("n_mismatch_errors")
             logging.warning(
                 f"Paragraph count mismatch (attempt {attempt + 1}): {e}. Retrying..."
             )
+            if not is_last:
+                metrics.incr("n_mismatch_retries")
         except ClientError as e:
             if e.code == 429 and e.status == "RESOURCE_EXHAUSTED":
+                metrics.incr("n_429_errors")
                 retry_delay = default_delay
                 try:
                     retry_info = next(
@@ -109,6 +127,8 @@ def retry_with_delay(func, *args, max_retries=5, default_delay=10, **kwargs):
                     )
                 logging.warning(f"RESOURCE_EXHAUSTED. Retrying in {retry_delay}s...")
                 time.sleep(retry_delay)
+                if not is_last:
+                    metrics.incr("n_429_retries")
             else:
                 logging.error(f"Unexpected ClientError: {e}")
                 raise e
@@ -123,6 +143,7 @@ def retry_with_delay(func, *args, max_retries=5, default_delay=10, **kwargs):
 def translate_text_with_gemini(
     paragraphs: list[str],
     model_name: str = DEFAULT_GEMINI_MODEL_NAME,
+    metrics: MetricsCollector | NullMetricsCollector | None = None,
 ) -> list[str]:
     """Translate a list of paragraphs, returning a list of the same length.
 
@@ -133,14 +154,19 @@ def translate_text_with_gemini(
     if not paragraphs:
         return []
 
+    metrics = metrics or NullMetricsCollector()
     max_retries = 3 if len(paragraphs) >= 80 else 5
     try:
         return _translate_text_batch_with_retry(
-            paragraphs, model_name=model_name, max_retries=max_retries
+            paragraphs,
+            model_name=model_name,
+            max_retries=max_retries,
+            metrics=metrics,
         )
     except RuntimeError:
         if len(paragraphs) <= 1:
             raise
+        metrics.incr("n_split_fallbacks")
         mid = len(paragraphs) // 2
         logging.warning(
             "Falling back to split translation for %d paragraphs (%d + %d).",
@@ -148,16 +174,27 @@ def translate_text_with_gemini(
             mid,
             len(paragraphs) - mid,
         )
-        left = translate_text_with_gemini(paragraphs[:mid], model_name=model_name)
-        right = translate_text_with_gemini(paragraphs[mid:], model_name=model_name)
+        # Recursive halves MUST receive the same metrics — otherwise all
+        # downstream api_call / 429 / mismatch counts from the split would
+        # be silently dropped.
+        left = translate_text_with_gemini(
+            paragraphs[:mid], model_name=model_name, metrics=metrics
+        )
+        right = translate_text_with_gemini(
+            paragraphs[mid:], model_name=model_name, metrics=metrics
+        )
         return left + right
 
 
 def translate_image_with_gemini(
     pil_image,
     model_name: str = DEFAULT_GEMINI_MODEL_NAME,
+    metrics: MetricsCollector | NullMetricsCollector | None = None,
 ) -> list[ImageTranslation]:
+    metrics = metrics or NullMetricsCollector()
+
     def call_gemini_api():
+        metrics.incr("n_image_api_calls")
         response = _get_client().models.generate_content(
             model=model_name,
             contents=[IMAGE_TRANSLATION_PROMPT, pil_image],
@@ -168,4 +205,4 @@ def translate_image_with_gemini(
         )
         return response.parsed
 
-    return retry_with_delay(call_gemini_api)
+    return retry_with_delay(call_gemini_api, metrics=metrics)

--- a/utils/translation_runner.py
+++ b/utils/translation_runner.py
@@ -4,12 +4,17 @@ import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from utils.config import DEFAULT_GEMINI_MODEL_NAME
+from utils.metrics import MetricsCollector, NullMetricsCollector
 from utils.translation import translate_image_with_gemini, translate_text_with_gemini
 
 log = logging.getLogger(__name__)
 
 
-def _translate_single_chunk(chunk: dict, model_name: str) -> dict:
+def _translate_single_chunk(
+    chunk: dict,
+    model_name: str,
+    metrics: MetricsCollector | NullMetricsCollector,
+) -> dict:
     """Translate one chunk (sets chunk['translated']) and return it.
 
     TEXT chunks: content is list[str], translated becomes list[str] of same length.
@@ -17,7 +22,9 @@ def _translate_single_chunk(chunk: dict, model_name: str) -> dict:
     """
     if chunk["type"] == "TEXT":
         paragraphs: list[str] = chunk["content"]
-        translated = translate_text_with_gemini(paragraphs, model_name)
+        translated = translate_text_with_gemini(
+            paragraphs, model_name, metrics=metrics
+        )
         log.info(
             "TEXT chunk translated: %d paragraphs in -> %d out",
             len(paragraphs),
@@ -26,7 +33,7 @@ def _translate_single_chunk(chunk: dict, model_name: str) -> dict:
         chunk["translated"] = translated
     elif chunk["type"] == "FIGURE":
         chunk["translated"] = translate_image_with_gemini(
-            chunk["content"], model_name
+            chunk["content"], model_name, metrics=metrics
         )
     return chunk
 
@@ -35,10 +42,12 @@ def translate_chunks_sequential(
     chunks: list[dict],
     model_name: str = DEFAULT_GEMINI_MODEL_NAME,
     progress_callback=None,
+    metrics_collector: MetricsCollector | NullMetricsCollector | None = None,
 ) -> list[dict]:
     """Translate chunks one by one. Used by benchmark only."""
+    metrics = metrics_collector or NullMetricsCollector()
     for i, chunk in enumerate(chunks):
-        _translate_single_chunk(chunk, model_name)
+        _translate_single_chunk(chunk, model_name, metrics)
         if progress_callback is not None:
             progress_callback(i + 1, len(chunks))
     return chunks
@@ -49,23 +58,47 @@ def translate_chunks_parallel(
     model_name: str = DEFAULT_GEMINI_MODEL_NAME,
     max_workers: int = 8,
     progress_callback=None,
+    metrics_collector: MetricsCollector | NullMetricsCollector | None = None,
 ) -> list[dict]:
-    """Translate chunks in parallel; return chunks in original order with 'translated' set."""
+    """Translate chunks in parallel; return chunks in original order with 'translated' set.
+
+    Fail-fast: first chunk failure raises. Before re-raising we call
+    ``record_failed_chunk()`` exactly once so the run metrics row records
+    a single failure. In-flight tasks drain naturally when the
+    ``ThreadPoolExecutor`` context exits; their results are discarded
+    and not counted as additional failures.
+    """
+    metrics = metrics_collector or NullMetricsCollector()
     total = len(chunks)
     results: list[dict | None] = [None] * total
 
     def task(index: int):
         chunk = chunks[index]
-        return index, _translate_single_chunk(dict(chunk), model_name)
+        return index, _translate_single_chunk(dict(chunk), model_name, metrics)
 
     completed = 0
+    failure_recorded = False
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {executor.submit(task, i): i for i in range(total)}
-        for future in as_completed(futures):
-            index, translated_chunk = future.result()
-            results[index] = translated_chunk
-            completed += 1
-            if progress_callback is not None:
-                progress_callback(completed, total)
+        try:
+            for future in as_completed(futures):
+                try:
+                    index, translated_chunk = future.result()
+                except Exception:
+                    if not failure_recorded:
+                        metrics.record_failed_chunk()
+                        failure_recorded = True
+                    raise
+                results[index] = translated_chunk
+                completed += 1
+                if progress_callback is not None:
+                    progress_callback(completed, total)
+        except Exception:
+            # Best-effort cancel of not-yet-started tasks. Already-running
+            # ones will be awaited by the context manager but their
+            # results are dropped on the floor.
+            for f in futures:
+                f.cancel()
+            raise
 
     return [c for c in results if c is not None]


### PR DESCRIPTION
## Summary

Brings the full metrics → Google Sheets pipeline onto main, plus two follow-ups from the first cloud run:

- `MetricsCollector` with bounded sampler/flusher daemons, `_counter_lock → _buffer_lock → _sink_io_lock` ordering, `MAX_BUFFER_ROWS=2000` drop-oldest policy, finalize w/ `_sink_io_lock.acquire(timeout=3.0s)` skip-on-timeout.
- `SheetsSink` (gspread + service-account secrets) with append-only fallback when `running` row append fails.
- Counters wired through `translation.py` / `translation_runner.py` (text/image api calls, 429 errors vs retries, mismatch errors vs retries, split fallbacks, failed chunks only counted at the runner).
- Seed phase before sampler thread starts so the first `samples` row isn't blank.
- Hidden `?workers=N` query param (clamped 1..32) for A/B-tuning on Streamlit Cloud without redeploys; falls back to `TRANSLATION_MAX_WORKERS`. `runs.workers` records actual value used.

Design doc: [docs/PLAN_metrics_to_sheets.md](docs/PLAN_metrics_to_sheets.md).

## Test plan

- [ ] Streamlit Cloud picks up the merge and the app boots
- [ ] Translate a doc with default URL → `runs` row appears, `samples` first row has `phase=translating`
- [ ] Translate same doc with `?workers=12` → `runs.workers=12`, samples accumulate
- [ ] Translate with `?workers=16` and `?workers=20` → watch `peak_ram_mb`, `n_429_errors`, `duration_translate_s`
- [ ] Force a failure (bad GEMINI_API_KEY) → `runs.status=error`, `error_type` / `error_short` populated, translation page still recovers
- [ ] Confirm Streamlit Cloud logs show no metrics-related tracebacks on the happy path