### PR TITLE
Stop Gemini 429 amplification, fail fast on quota wall, add Discord alerts

### DIFF
--- a/.streamlit/secrets.example.toml
+++ b/.streamlit/secrets.example.toml
@@ -3,6 +3,11 @@
 
 GEMINI_API_KEY = "your_gemini_api_key"
 
+# Discord failure alerts (optional). Set a webhook URL to get a Discord ping
+# when the SAME document fails this many times in a row (DISCORD_ALERT_THRESHOLD
+# in utils/config.py, default 2). Leave unset/empty to disable alerts.
+discord_webhook_url = "https://discord.com/api/webhooks/your_webhook_id/your_token"
+
 # Metrics sink (optional). Set metrics_enabled = true and the
 # gcp_service_account / metrics_sheet_id below to push run metrics to
 # Google Sheets. With metrics_enabled = false (default) the metrics code

--- a/app.py
+++ b/app.py
@@ -15,7 +15,11 @@ from utils import (
     parse_docx_with_images,
     translate_chunks_parallel,
 )
-from utils.config import METRICS_ENABLED_ENV_VAR, TRANSLATION_MAX_WORKERS
+from utils.config import (
+    DISCORD_ALERT_THRESHOLD,
+    METRICS_ENABLED_ENV_VAR,
+    TRANSLATION_MAX_WORKERS,
+)
 from utils.metrics import (
     PHASE_BUILDING_DOC,
     PHASE_TRANSLATING,
@@ -27,6 +31,8 @@ from utils.metrics import (
     set_active_collector,
 )
 from utils.metrics_sheets import build_sheets_sink_from_secrets
+from utils.notifications import notify_discord_failure
+from utils.translation import QuotaExhaustedError
 
 log = logging.getLogger(__name__)
 
@@ -188,11 +194,63 @@ def _count_output_chars(translated_chunks):
     return total
 
 
+def _describe_error(error: BaseException | None) -> str:
+    """Short Korean reason string for logs / Discord alerts."""
+    if isinstance(error, QuotaExhaustedError):
+        if error.scope == "per_day":
+            return f"Gemini 일일 쿼터/크레딧 소진 (결제·크레딧 확인 필요) — {error.detail}"
+        if error.scope == "per_minute":
+            return f"Gemini 분당 요청 한도 초과 (일시적) — {error.detail}"
+        return f"Gemini 쿼터 초과 — {error.detail}"
+    if error is None:
+        return "알 수 없는 오류"
+    return f"{type(error).__name__}: {error}"
+
+
+def _show_error_message(error: BaseException | None) -> None:
+    """Render a friendly st.error instead of leaking a raw traceback."""
+    if isinstance(error, QuotaExhaustedError) and error.scope == "per_day":
+        st.error(
+            "❌ Gemini 사용량/크레딧이 소진되어 번역에 실패했습니다.\n\n"
+            "결제 크레딧 잔액과, API 키가 속한 프로젝트의 결제 연결을 확인해 주세요. "
+            "일일 한도라면 태평양시간(PT) 자정에 초기화됩니다."
+        )
+    elif isinstance(error, QuotaExhaustedError):
+        st.error(
+            "❌ Gemini 요청 한도를 초과했습니다. 잠시 후 다시 시도하거나 "
+            "동시 작업 수(`?workers=N`)를 줄여 주세요."
+        )
+    else:
+        st.error("❌ 번역 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.")
+
+
+def _handle_failure(doc_name: str, error: BaseException | None, workers: int) -> None:
+    """Count consecutive failures of this doc; alert Discord past the threshold."""
+    counts = st.session_state.setdefault("failure_counts", {})
+    counts[doc_name] = counts.get(doc_name, 0) + 1
+    n = counts[doc_name]
+    log.warning("[run] translation failed (%s, %d회): %s", doc_name, n, _describe_error(error))
+    _show_error_message(error)
+    if n >= DISCORD_ALERT_THRESHOLD:
+        notify_discord_failure(
+            doc_name=doc_name,
+            consecutive_failures=n,
+            reason=_describe_error(error),
+            workers=workers,
+            model=DEFAULT_GEMINI_MODEL_NAME,
+        )
+
+
 # 번역 실행
 def run_translation(workers: int):
     chunks = st.session_state.chunked_elements
     total = len(chunks)
     doc = create_japanese_patent_docx()
+    doc_name = (
+        getattr(uploaded_file, "name", "")
+        or st.session_state.get("last_uploaded_filename", "")
+        or "(이름 없음)"
+    )
 
     def progress_cb(completed, total_n):
         progress_placeholder.progress(
@@ -227,14 +285,23 @@ def run_translation(workers: int):
 
         st.session_state.translated = True
         status = STATUS_OK
-    except BaseException as e:
+    except Exception as e:
+        # Swallow translation failures here (instead of re-raising into a raw
+        # Streamlit traceback) so the user gets a friendly message and we can
+        # track/alert on repeated failures. Truly fatal BaseExceptions
+        # (KeyboardInterrupt/SystemExit) still propagate.
         error = e
-        raise
     finally:
         try:
             collector.stop_and_finalize(status, error=error)
         except Exception:
             log.exception("[metrics] stop_and_finalize raised; ignoring")
+
+    if status == STATUS_OK:
+        # Clear the consecutive-failure streak for this document.
+        st.session_state.setdefault("failure_counts", {}).pop(doc_name, None)
+    else:
+        _handle_failure(doc_name, error, workers)
 
 
 # 번역 시작 버튼

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pydantic
 psutil
 gspread
 google-auth
+requests

--- a/tests/test_retry_and_quota.py
+++ b/tests/test_retry_and_quota.py
@@ -1,0 +1,182 @@
+import unittest
+from unittest.mock import patch
+
+from google.genai.errors import ClientError
+
+from utils import translation
+from utils.translation import (
+    ParagraphMismatchError,
+    QuotaExhaustedError,
+    RetriesExhaustedError,
+    _classify_quota_scope,
+    extract_retry_delay_seconds,
+)
+
+PER_MINUTE = "generativelanguage.googleapis.com/generate_requests_per_minute_per_project"
+PER_DAY = "generativelanguage.googleapis.com/generate_requests_per_day_per_project"
+FREE_TIER = "generativelanguage.googleapis.com/generate_content_free_tier_requests"
+
+
+def make_429(
+    metric: str, retry_delay=None, *, wrap: bool = True, quota_id: str | None = None
+) -> ClientError:
+    """Build a ClientError shaped like a real Gemini 429 RESOURCE_EXHAUSTED.
+
+    ``wrap=True`` mimics the sync httpx path (full body with the top-level
+    ``error`` key, which is what sets .status); ``wrap=False`` mimics the
+    already-unwrapped replay/aiohttp shape. ``quota_id`` lets a test set
+    ``quotaId`` distinct from ``quotaMetric`` (they can disagree in the wild).
+    """
+    details = [
+        {
+            "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+            "violations": [
+                {"quotaMetric": metric, "quotaId": quota_id or metric}
+            ],
+        }
+    ]
+    if retry_delay is not None:
+        details.append(
+            {
+                "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                "retryDelay": retry_delay,
+            }
+        )
+    inner = {
+        "code": 429,
+        "status": "RESOURCE_EXHAUSTED",
+        "message": f"Resource has been exhausted: {metric}",
+        "details": details,
+    }
+    body = {"error": inner} if wrap else inner
+    return ClientError(429, body)
+
+
+class TestRetryDelayExtraction(unittest.TestCase):
+    def test_full_body_integer_seconds(self):
+        e = make_429(PER_MINUTE, retry_delay="30s")
+        self.assertEqual(extract_retry_delay_seconds(e), 30.0)
+
+    def test_fractional_seconds(self):
+        e = make_429(PER_MINUTE, retry_delay="17.5s")
+        self.assertEqual(extract_retry_delay_seconds(e), 17.5)
+
+    def test_unwrapped_shape_still_parses(self):
+        e = make_429(PER_MINUTE, retry_delay="42s", wrap=False)
+        self.assertEqual(extract_retry_delay_seconds(e), 42.0)
+
+    def test_dict_duration(self):
+        e = make_429(PER_MINUTE, retry_delay={"seconds": "5", "nanos": 500000000})
+        self.assertAlmostEqual(extract_retry_delay_seconds(e), 5.5)
+
+    def test_absent_retry_info_returns_none(self):
+        e = make_429(PER_DAY)  # no RetryInfo (typical for daily quota)
+        self.assertIsNone(extract_retry_delay_seconds(e))
+
+
+class TestQuotaScopeClassification(unittest.TestCase):
+    def test_per_minute(self):
+        self.assertEqual(_classify_quota_scope(make_429(PER_MINUTE)), "per_minute")
+
+    def test_per_day(self):
+        self.assertEqual(_classify_quota_scope(make_429(PER_DAY)), "per_day")
+
+    def test_free_tier_is_per_day(self):
+        self.assertEqual(_classify_quota_scope(make_429(FREE_TIER)), "per_day")
+
+    def test_free_tier_metric_wins_over_minute_quota_id(self):
+        # quotaMetric carries the free-tier (credit-wall) signal while quotaId
+        # mentions PerMinute — must still fail fast as per_day, and the
+        # free_tier signal must not be dropped by capturing only one field.
+        e = make_429(FREE_TIER, quota_id="GenerateRequestsPerMinutePerProjectFreeTier")
+        self.assertEqual(_classify_quota_scope(e), "per_day")
+
+    def test_unknown(self):
+        self.assertEqual(_classify_quota_scope(make_429("some/opaque_metric")), "unknown")
+
+
+class TestRetryWithDelay(unittest.TestCase):
+    def test_per_day_fails_fast_without_sleeping(self):
+        calls = {"n": 0}
+
+        def call():
+            calls["n"] += 1
+            raise make_429(PER_DAY)
+
+        with patch("utils.translation.time.sleep") as sleep:
+            with self.assertRaises(QuotaExhaustedError) as ctx:
+                translation.retry_with_delay(call, max_retries=5)
+
+        self.assertEqual(calls["n"], 1)  # no retries on a daily wall
+        self.assertEqual(ctx.exception.scope, "per_day")
+        sleep.assert_not_called()
+
+    def test_per_minute_retries_then_raises_quota_error(self):
+        calls = {"n": 0}
+
+        def call():
+            calls["n"] += 1
+            raise make_429(PER_MINUTE, retry_delay="0s")
+
+        with patch("utils.translation.time.sleep") as sleep:
+            with self.assertRaises(QuotaExhaustedError) as ctx:
+                translation.retry_with_delay(call, max_retries=3)
+
+        self.assertEqual(calls["n"], 3)
+        self.assertEqual(ctx.exception.scope, "per_minute")
+        self.assertEqual(sleep.call_count, 2)  # sleeps between attempts, not after last
+
+    def test_mismatch_exhaustion_raises_retries_exhausted(self):
+        def call():
+            raise ParagraphMismatchError("nope")
+
+        with self.assertRaises(RetriesExhaustedError):
+            translation.retry_with_delay(call, max_retries=2)
+
+    def test_success_after_one_mismatch(self):
+        calls = {"n": 0}
+
+        def call():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ParagraphMismatchError("retry me")
+            return ["ok"]
+
+        result = translation.retry_with_delay(call, max_retries=5)
+        self.assertEqual(result, ["ok"])
+        self.assertEqual(calls["n"], 2)
+
+
+class TestNoSplitOnQuota(unittest.TestCase):
+    def test_quota_error_propagates_without_splitting(self):
+        paragraphs = [f"p{i}" for i in range(6)]
+
+        with patch(
+            "utils.translation._translate_text_batch_with_retry",
+            side_effect=QuotaExhaustedError("per_day", "credits gone"),
+        ) as mock_batch:
+            with self.assertRaises(QuotaExhaustedError):
+                translation.translate_text_with_gemini(paragraphs, model_name="m")
+
+        # Exactly one call — no recursive half-splitting.
+        self.assertEqual(mock_batch.call_count, 1)
+
+    def test_quota_error_does_not_increment_split_fallback(self):
+        from utils.metrics import MetricsCollector, NullSink
+
+        collector = MetricsCollector(NullSink())
+        with patch(
+            "utils.translation._translate_text_batch_with_retry",
+            side_effect=QuotaExhaustedError("per_minute", "rpm"),
+        ):
+            with self.assertRaises(QuotaExhaustedError):
+                translation.translate_text_with_gemini(
+                    [f"p{i}" for i in range(6)], model_name="m", metrics=collector
+                )
+
+        with collector._counter_lock:
+            self.assertEqual(collector._counters["n_split_fallbacks"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/config.py
+++ b/utils/config.py
@@ -2,8 +2,10 @@
 DEFAULT_GEMINI_MODEL_NAME = "gemini-2.5-flash"
 DEFAULT_GEMINI_MODEL_DISPLAY_NAME = "Gemini 2.5 Flash"
 
-# Parallel translation: max concurrent API requests (Tier 1 friendly)
-TRANSLATION_MAX_WORKERS = 8
+# Parallel translation: max concurrent API requests (Tier 1 friendly).
+# Bumped from 8 → 16 after observing ample headroom in metrics
+# (peak RAM ~430MB on the largest run, CPU 1-3%, zero 429s on clean runs).
+TRANSLATION_MAX_WORKERS = 16
 
 # Metrics → Google Sheets sink. Off by default; flip via env METRICS_ENABLED=1
 # or st.secrets["metrics_enabled"] (handled in utils/metrics.py).

--- a/utils/config.py
+++ b/utils/config.py
@@ -7,6 +7,11 @@ DEFAULT_GEMINI_MODEL_DISPLAY_NAME = "Gemini 2.5 Flash"
 # (peak RAM ~430MB on the largest run, CPU 1-3%, zero 429s on clean runs).
 TRANSLATION_MAX_WORKERS = 16
 
+# Discord failure alerts. Webhook URL via st.secrets["discord_webhook_url"] or
+# env DISCORD_WEBHOOK_URL (handled in utils/notifications.py). An alert fires
+# once the SAME document fails this many times in a row within a session.
+DISCORD_ALERT_THRESHOLD = 2
+
 # Metrics → Google Sheets sink. Off by default; flip via env METRICS_ENABLED=1
 # or st.secrets["metrics_enabled"] (handled in utils/metrics.py).
 METRICS_ENABLED_ENV_VAR = "METRICS_ENABLED"

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -1,0 +1,81 @@
+"""Best-effort Discord webhook alerts.
+
+Kept dependency-light and fully fail-safe: ``requests`` is imported lazily and
+every failure is swallowed + logged, so a missing webhook / network blip / bad
+URL can NEVER break the translation flow. Configure via
+``st.secrets["discord_webhook_url"]`` or the ``DISCORD_WEBHOOK_URL`` env var.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+# Discord rejects messages over 2000 chars; stay well under.
+_MAX_CONTENT = 1900
+
+
+def _webhook_url() -> str | None:
+    try:
+        import streamlit as st
+
+        url = st.secrets.get("discord_webhook_url")
+        if url:
+            return str(url)
+    except Exception:
+        pass
+    return os.environ.get("DISCORD_WEBHOOK_URL") or None
+
+
+def notify_discord(content: str, *, username: str = "한일 특허 번역기") -> bool:
+    """POST ``content`` to the configured Discord webhook. Returns success.
+
+    No-op (returns ``False``) when no webhook is configured. Never raises.
+    """
+    url = _webhook_url()
+    if not url:
+        log.info("[discord] webhook not configured; skipping alert")
+        return False
+    try:
+        import requests
+
+        resp = requests.post(
+            url,
+            json={"content": content[:_MAX_CONTENT], "username": username},
+            timeout=5,
+        )
+        if resp.status_code >= 300:
+            log.warning(
+                "[discord] webhook returned %s: %s",
+                resp.status_code,
+                resp.text[:200],
+            )
+            return False
+        return True
+    except Exception:
+        log.exception("[discord] failed to send webhook")
+        return False
+
+
+def notify_discord_failure(
+    *,
+    doc_name: str,
+    consecutive_failures: int,
+    reason: str,
+    workers: int,
+    model: str,
+) -> bool:
+    """Send a formatted '번역 실패' alert. Never raises."""
+    ts = datetime.now(timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+    content = (
+        "🔴 **번역 실패 알림**\n"
+        f"• 문서: `{doc_name or '(이름 없음)'}`\n"
+        f"• 연속 실패: **{consecutive_failures}회**\n"
+        f"• 사유: {reason}\n"
+        f"• 워커/모델: {workers} / {model}\n"
+        f"• 시각: {ts}"
+    )
+    return notify_discord(content)

--- a/utils/translation.py
+++ b/utils/translation.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import random
+import re
 import threading
 import time
 
@@ -58,6 +60,131 @@ class ParagraphMismatchError(Exception):
     """Raised when the translated paragraph count doesn't match the source."""
 
 
+class QuotaExhaustedError(RuntimeError):
+    """A 429 RESOURCE_EXHAUSTED that could not be recovered within the run.
+
+    ``scope`` is one of:
+      - ``"per_day"``   — daily quota / credits gone; will NOT recover this run
+                          (reset is at midnight Pacific, or needs billing top-up).
+      - ``"per_minute"``— per-minute throttle that outlasted our retries.
+      - ``"unknown"``   — quota metric could not be parsed.
+
+    Subclass of ``RuntimeError`` so existing ``except RuntimeError`` sites keep
+    catching it, but callers can branch on ``isinstance`` to AVOID splitting a
+    chunk on a quota wall (splitting just multiplies doomed/paid requests).
+    """
+
+    def __init__(self, scope: str = "unknown", detail: str = ""):
+        self.scope = scope
+        self.detail = detail
+        msg = f"Gemini quota exhausted (scope={scope})"
+        if detail:
+            msg = f"{msg}: {detail}"
+        super().__init__(msg)
+
+
+class RetriesExhaustedError(RuntimeError):
+    """Retries exhausted for a NON-quota cause (e.g. paragraph count mismatch).
+
+    Kept distinct from :class:`QuotaExhaustedError` so the split fallback only
+    fires for the recoverable mismatch case, never for rate limiting.
+    """
+
+
+# Backoff ceiling for a single retry sleep (seconds).
+MAX_BACKOFF_S = 60
+
+
+def _error_body(exc: ClientError) -> dict:
+    """Return the inner error object from a google.genai APIError.
+
+    ``exc.details`` is stored verbatim and may be either the full body
+    ``{"error": {...}}`` (sync httpx path) or the already-unwrapped inner
+    object ``{"code","status","details":[...]}`` (replay/aiohttp paths), or a
+    message-only fallback with neither key. Normalize all of them to the inner
+    object (or ``{}``).
+    """
+    details = getattr(exc, "details", None)
+    if not isinstance(details, dict):
+        return {}
+    inner = details.get("error")
+    return inner if isinstance(inner, dict) else details
+
+
+def _error_detail_items(exc: ClientError) -> list:
+    items = _error_body(exc).get("details")
+    return items if isinstance(items, list) else []
+
+
+def extract_retry_delay_seconds(exc: ClientError) -> float | None:
+    """Pull the server-suggested retry delay from a google.rpc.RetryInfo detail.
+
+    Returns ``None`` when absent (common for per-day quota 429s) or fractional
+    parsing fails, so the caller falls back to its own backoff. Handles both the
+    ``"30s"`` / ``"17.5s"`` string Duration and the ``{"seconds","nanos"}`` dict.
+    """
+    for item in _error_detail_items(exc):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("@type", "")).endswith("RetryInfo"):
+            raw = item.get("retryDelay")
+            if isinstance(raw, str):
+                m = re.match(r"\s*([0-9]*\.?[0-9]+)s", raw)
+                if m:
+                    return float(m.group(1))
+            elif isinstance(raw, dict):
+                return float(raw.get("seconds", 0)) + float(raw.get("nanos", 0)) / 1e9
+    return None
+
+
+def _quota_detail(exc: ClientError) -> str:
+    """Human-readable quota info: the error message plus any QuotaFailure ids.
+
+    This is exactly what the previous code SWALLOWED — it carries the decisive
+    'free_tier' / 'PerDay' / 'PerMinute' signal that distinguishes a transient
+    throttle from a hard daily/credit wall.
+    """
+    parts: list[str] = []
+    msg = getattr(exc, "message", None)
+    if msg:
+        parts.append(str(msg))
+    for item in _error_detail_items(exc):
+        if not isinstance(item, dict) or not str(item.get("@type", "")).endswith(
+            "QuotaFailure"
+        ):
+            continue
+        for v in item.get("violations", []) or []:
+            if isinstance(v, dict):
+                # Capture BOTH fields — the decisive 'free_tier'/'PerDay' token
+                # can live in either one, so picking just one can drop it.
+                for key in ("quotaMetric", "quotaId"):
+                    val = v.get(key)
+                    if val:
+                        parts.append(str(val))
+    return " | ".join(parts)
+
+
+def _classify_quota_scope(exc: ClientError) -> str:
+    """'per_day' | 'per_minute' | 'unknown' from the quota metric/message.
+
+    Precedence is deliberate:
+      1. 'free_tier' → per_day. On a *paid* project a free-tier quota id only
+         appears once credits are exhausted (the project falls back to free
+         tier) — a wall that will NOT clear within this run, so fail fast even
+         if a 'PerMinute' token co-occurs.
+      2. explicit 'day'/'daily' → per_day.
+      3. 'minute' → per_minute (transient; worth a backoff retry).
+    """
+    text = _quota_detail(exc).lower()
+    if "free_tier" in text or "freetier" in text:
+        return "per_day"
+    if "day" in text or "daily" in text:
+        return "per_day"
+    if "minute" in text:
+        return "per_minute"
+    return "unknown"
+
+
 def _translate_text_batch_with_retry(
     paragraphs: list[str],
     model_name: str,
@@ -96,6 +223,7 @@ def retry_with_delay(
     **kwargs,
 ):
     metrics = metrics or NullMetricsCollector()
+    last_quota_error: ClientError | None = None
     for attempt in range(max_retries):
         is_last = attempt == max_retries - 1
         try:
@@ -112,30 +240,48 @@ def retry_with_delay(
                 metrics.incr("n_mismatch_retries")
         except ClientError as e:
             if e.code == 429 and e.status == "RESOURCE_EXHAUSTED":
+                last_quota_error = e
                 metrics.incr("n_429_errors")
-                retry_delay = default_delay
-                try:
-                    retry_info = next(
-                        detail
-                        for detail in e.details["error"]["details"]
-                        if detail["@type"] == "type.googleapis.com/google.rpc.RetryInfo"
-                    )
-                    retry_delay = int(retry_info["retryDelay"].strip("s"))
-                except (StopIteration, KeyError, ValueError):
-                    logging.warning(
-                        "Failed to extract retryDelay. Using default delay."
-                    )
-                logging.warning(f"RESOURCE_EXHAUSTED. Retrying in {retry_delay}s...")
-                time.sleep(retry_delay)
-                if not is_last:
-                    metrics.incr("n_429_retries")
+                scope = _classify_quota_scope(e)
+                # Surface the REAL quota message (free_tier / PerDay / PerMinute)
+                # — previously swallowed behind a generic "Retrying" log.
+                logging.warning(
+                    "RESOURCE_EXHAUSTED [%s]: %s", scope, _quota_detail(e)
+                )
+                # A daily / credit wall will NOT recover within this run. Fail
+                # fast instead of burning retries — and, since splitting is
+                # disabled for this error, this stops the request-amplification
+                # storm at the source.
+                if scope == "per_day":
+                    raise QuotaExhaustedError(scope, _quota_detail(e)) from e
+                if is_last:
+                    continue
+                # Exponential backoff with full jitter, honoring the server's
+                # RetryInfo hint when present. Jitter desynchronizes the worker
+                # threads so they stop retrying in lockstep.
+                server_delay = extract_retry_delay_seconds(e)
+                if server_delay is not None:
+                    sleep_s = server_delay + random.uniform(0, 1.0)
+                else:
+                    cap = min(default_delay * (2**attempt), MAX_BACKOFF_S)
+                    sleep_s = random.uniform(0, cap)
+                logging.warning(f"RESOURCE_EXHAUSTED. Retrying in {sleep_s:.1f}s...")
+                time.sleep(sleep_s)
+                metrics.incr("n_429_retries")
             else:
                 logging.error(f"Unexpected ClientError: {e}")
                 raise e
         except Exception as e:
             logging.error(f"Unexpected error: {e}")
             raise e
-    raise RuntimeError(
+    if last_quota_error is not None:
+        # Retries exhausted on a (per-minute/unknown) 429 — typed so callers
+        # never route a quota failure into the split fallback.
+        raise QuotaExhaustedError(
+            _classify_quota_scope(last_quota_error),
+            _quota_detail(last_quota_error),
+        ) from last_quota_error
+    raise RetriesExhaustedError(
         f"Failed to execute {func.__name__} after {max_retries} retries."
     )
 
@@ -163,6 +309,12 @@ def translate_text_with_gemini(
             max_retries=max_retries,
             metrics=metrics,
         )
+    except QuotaExhaustedError:
+        # NEVER split on a quota/credit wall. Splitting recursively re-calls
+        # this function on each half, multiplying doomed (and, on pay-as-you-go,
+        # billed) requests against an already-empty quota — turning one doomed
+        # 99-paragraph call into ~983 of them. Let it propagate immediately.
+        raise
     except RuntimeError:
         if len(paragraphs) <= 1:
             raise


### PR DESCRIPTION
## Summary

선불(pay-as-you-go) 전환 후 크레딧이 소진되면서 해당 프로젝트가 무료 티어로 강등되어, 번역 시작과 동시에 모든 요청이 즉시 `429 RESOURCE_EXHAUSTED`로 실패하는 사고가 있었습니다.

문제는 단순 실패가 아니라 **재시도/분할 폴백 로직이 429를 폭발적으로 증폭**시킨 점입니다. `translate_text_with_gemini`의 split fallback이 *모든* `RuntimeError`(문단 불일치든 429든)를 잡아 청크를 반으로 쪼개 재귀 호출했기 때문에, **99문단 청크 1개가 ~983회의 헛된 API 호출**이 되었고 워커 16개 기준으로는 한 번 실행에 수천 회까지 늘어났습니다. 선불 종량제에서는 이게 곧 **실제 비용**입니다.

이 PR은 ① 그 증폭을 끊고, ② 쿼터/크레딧 벽에서는 즉시 실패시키며, ③ 같은 문서가 반복 실패하면 Discord로 알림을 보냅니다.

---

## What Changed

### Before
- split fallback이 429에도 발동 → 쿼터가 비었는데 요청을 곱절로 늘림 (99 → ~983회)
- 고정 10초 지연으로 워커들이 lockstep 재시도 (thundering herd), 백오프·jitter 없음
- `retryDelay` 추출이 매번 실패 (소수 `17.5s`/RetryInfo 부재 미처리) → 항상 기본 10초
- 실제 쿼터 메시지(`free_tier`/`PerDay`/`PerMinute`)를 로그에서 버림 → RPM/RPD 구분 불가
- 실패 시 사용자에게 raw Streamlit 트레이스백 노출, 반복 실패를 알 방법은 로그 뒤지기뿐

### After
- 429를 `per_day`/`per_minute`/`unknown`으로 분류, 쿼터 오류엔 **절대 split 안 함**
- `per_day`(크레딧·일일 벽)는 **재시도 없이 즉시 중단** → 한 번 실행에 워커당 1~수회로 축소
- `per_minute`는 **지수 백오프 + full jitter**, 서버 `RetryInfo` 힌트 존중(소수/`{seconds,nanos}` 형태 모두 파싱)
- `QuotaExhaustedError` / `RetriesExhaustedError` 타입 분리로 split은 문단 불일치 케이스에만 발동
- 실제 쿼터 메시지를 로그에 노출 (`quotaMetric`+`quotaId` 둘 다 수집)
- 친화적 에러 UI + **문서별 연속 실패 카운트**, 임계치 도달 시 Discord 웹훅 알림

---

## 429 처리 흐름 (After)

```mermaid
flowchart TD
  A["TEXT 청크 번역 시도"] --> B{"결과?"}
  B -- 성공 --> C["반환"]
  B -- "문단 수 불일치" --> D{"재시도/분할"}
  B -- "429 RESOURCE_EXHAUSTED" --> E{"쿼터 종류?"}
  E -- "per_day / free_tier (크레딧·일일 벽)" --> F["즉시 중단 · 분할 X · 재시도 X"]
  E -- "per_minute (일시적)" --> G["지수 백오프 + jitter 재시도"]
  G -- 소진 --> F
  D -- "분할 가능(문단>1)" --> H["Left/Right 분할 후 재귀"]
  D -- 불가 --> I["실패 전파"]
```

---

## Key changes

- `utils/translation.py`
  - `QuotaExhaustedError`(scope: per_day/per_minute/unknown) / `RetriesExhaustedError` 추가
  - `_classify_quota_scope` / `_quota_detail` / `extract_retry_delay_seconds` 추가
  - `retry_with_delay`: per_day fail-fast, 지수 백오프+jitter, 실제 쿼터 메시지 로깅
  - `translate_text_with_gemini`: `QuotaExhaustedError`는 split 없이 즉시 전파
- `utils/notifications.py` (신규)
  - fail-safe Discord 웹훅 (`requests` 지연 import, 실패는 swallow+log → 번역 흐름 영향 X)
- `app.py`
  - 실패를 catch해 친화적 메시지 표시, 문서별 연속 실패 카운트, 임계치 도달 시 Discord 알림(성공 시 리셋)
- `utils/config.py`
  - `DISCORD_ALERT_THRESHOLD = 2`, `TRANSLATION_MAX_WORKERS` 8 → 16 (메트릭상 여유 충분: peak RAM ~430MB, CPU 1-3%)
- `requirements.txt`: `requests` 명시
- `.streamlit/secrets.example.toml`: `discord_webhook_url` 문서화
- `tests/test_retry_and_quota.py` (신규): retryDelay 파싱/쿼터 분류/per_day 즉시중단/no-split-on-429 등 16종

---

## 배포 시 설정
- Streamlit secrets에 `discord_webhook_url = "https://discord.com/api/webhooks/.../..."` 추가 시 알림 활성화 (미설정이면 조용히 비활성). 환경변수 `DISCORD_WEBHOOK_URL`도 가능.
- 근본 원인은 코드가 아니라 **크레딧 소진**이었으므로, API 키가 속한 프로젝트의 결제/크레딧이 정상인지 확인 필요.

---

## Test plan
- [x] `python -m unittest discover -s tests` → 38 passed (기존 22 + 신규 16)
- [ ] Streamlit Cloud 머지 후 부팅 확인
- [ ] 정상 문서 번역 성공 (no 429)
- [ ] 의도적 실패(잘못된 GEMINI_API_KEY 등) → 친화적 에러 노출, raw 트레이스백 없음
- [ ] 같은 문서 연속 2회 실패 → Discord 알림 수신(사유/연속 횟수/워커·모델/시각)
- [ ] webhook 미설정 시 알림 없이 정상 동작
